### PR TITLE
Update CMakeList in examples to import and use RRC proto types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,13 @@ set(BUILD_SHARED_LIBS ON)
 
 add_subdirectory(src)
 
-if(BUILD_EXAMPLES)
+if( BUILD_EXAMPLES )
+    message("Adding example directory") 
     add_subdirectory(examples)
-endif(BUILD_EXAMPLES)
+endif( BUILD_EXAMPLES )
 
-if(BUILD_TESTS)
+if( BUILD_TESTS )
+    message("Adding test directory") 
     add_subdirectory(test)
-endif(BUILD_TESTS)
+endif( BUILD_TESTS )
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.1.0)
 
 #add_subdirectory(extending/src)
 

--- a/examples/extending/src/Types/CMakeLists.txt
+++ b/examples/extending/src/Types/CMakeLists.txt
@@ -1,14 +1,17 @@
 
 
 find_package(Protobuf REQUIRED)
+find_package(robot_remote_control REQUIRED)
 
 set(PROTOBUF_PACKAGENAME myrobot)
+set(robot_remote_control_DIR myrobot)
 
 add_custom_command( OUTPUT ${PROTOBUF_PACKAGENAME}.pb.cc ${PROTOBUF_PACKAGENAME}.pb.h
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    COMMAND protoc --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} ${PROTOBUF_PACKAGENAME}.proto
+		    COMMAND protoc -I ${robot_remote_control_DIR}/src/Types -I ${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${PROTOBUF_PACKAGENAME}.proto
                     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${PROTOBUF_PACKAGENAME}.pb.cc ${CMAKE_CURRENT_BINARY_DIR}/${PROTOBUF_PACKAGENAME}.pb.cc 
                     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${PROTOBUF_PACKAGENAME}.pb.h ${CMAKE_CURRENT_BINARY_DIR}/${PROTOBUF_PACKAGENAME}.pb.h
+		    COMMAND ${CMAKE_COMMAND} -E copy ${robot_remote_control_DIR}/src/Types/RobotRemoteControl.pb.h ${CMAKE_CURRENT_SOURCE_DIR}/
                     MAIN_DEPENDENCY ${PROTOBUF_PACKAGENAME}.proto
                     )
 

--- a/examples/extending/src/Types/CMakeLists.txt
+++ b/examples/extending/src/Types/CMakeLists.txt
@@ -4,14 +4,15 @@ find_package(Protobuf REQUIRED)
 find_package(robot_remote_control REQUIRED)
 
 set(PROTOBUF_PACKAGENAME myrobot)
-set(robot_remote_control_DIR myrobot)
+set(robot_remote_control_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/robot_remote_control/)
+set(protobuf_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/protobuf/)
 
 add_custom_command( OUTPUT ${PROTOBUF_PACKAGENAME}.pb.cc ${PROTOBUF_PACKAGENAME}.pb.h
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-		    COMMAND protoc -I ${robot_remote_control_DIR}/src/Types -I ${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${PROTOBUF_PACKAGENAME}.proto
+		    COMMAND protoc -I ${protobuf_DIR} -I ${CMAKE_CURRENT_SOURCE_DIR} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${PROTOBUF_PACKAGENAME}.proto
                     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${PROTOBUF_PACKAGENAME}.pb.cc ${CMAKE_CURRENT_BINARY_DIR}/${PROTOBUF_PACKAGENAME}.pb.cc 
                     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${PROTOBUF_PACKAGENAME}.pb.h ${CMAKE_CURRENT_BINARY_DIR}/${PROTOBUF_PACKAGENAME}.pb.h
-		    COMMAND ${CMAKE_COMMAND} -E copy ${robot_remote_control_DIR}/src/Types/RobotRemoteControl.pb.h ${CMAKE_CURRENT_SOURCE_DIR}/
+		    COMMAND ${CMAKE_COMMAND} -E copy ${robot_remote_control_DIR}/Types/RobotRemoteControl.pb.h ${CMAKE_CURRENT_SOURCE_DIR}/
                     MAIN_DEPENDENCY ${PROTOBUF_PACKAGENAME}.proto
                     )
 

--- a/examples/extending/src/Types/myrobot.proto
+++ b/examples/extending/src/Types/myrobot.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package myrobot;
 
-import "RobotRemoteControl.proto"
+import "RobotRemoteControl.proto";
 
 message NewControlMessage{
     int32 sequence_no = 1;

--- a/examples/extending/src/Types/myrobot.proto
+++ b/examples/extending/src/Types/myrobot.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package myrobot;
 
+import "RobotRemoteControl.proto"
 
 message NewControlMessage{
     int32 sequence_no = 1;


### PR DESCRIPTION
Reference the proto file, when executing the proto compiler command from within cmake.
Also copying installed RobotRemoteControl.pb.h header to src/Types directory. This is necessary as the generated myrobot.pb.h is referencing the header relatively (using ").