### PR TITLE
Implement Poses message type.

### DIFF
--- a/src/ControlledRobot/ControlledRobot.hpp
+++ b/src/ControlledRobot/ControlledRobot.hpp
@@ -230,6 +230,16 @@ class ControlledRobot: public UpdateThread{
         }
 
         /**
+         * @brief Set repeated field of poses
+         * 
+         * @param telemetry several pose
+         * @return int number of bytes sent
+         */
+        int setPoses(const Poses& telemetry) {
+            return sendTelemetry(telemetry, POSES);
+        }
+
+        /**
          * @brief Set the current JointState of the robot
          * 
          * @param telemetry current JointState

--- a/src/MessageTypes.hpp
+++ b/src/MessageTypes.hpp
@@ -36,6 +36,7 @@ namespace robot_remote_control {
                                 WRENCH_STATE,               // current Wrench values
                                 MAPS_DEFINITION,
                                 MAP,
+				POSES,                      // number of poses
                                 TELEMETRY_MESSAGE_TYPES_NUMBER  // LAST element
                             };
 

--- a/src/RobotController/RobotController.hpp
+++ b/src/RobotController/RobotController.hpp
@@ -85,6 +85,16 @@ class RobotController: public UpdateThread {
         }
 
         /**
+         * @brief Get an array of Poses
+         * 
+         * @param repeated field of poses to write the data to
+         * @return bool true if new data was read
+         */
+        bool getPoses(Poses *poses) {
+            return getTelemetry(POSES, poses);
+        }
+
+        /**
          * @brief Get the last sent joint state of the robot
          * 
          * @param jointState the JointState to write the data to

--- a/test/TypeGenerator.hpp
+++ b/test/TypeGenerator.hpp
@@ -31,6 +31,14 @@ class TypeGenerator{
         return data;
     }
 
+    static Poses genPoses() {
+        Poses data;
+        for (int values = 0; values < 10; ++values) {
+            *data.add_pose() = genPose();
+        }
+        return data;
+    }
+
     static Vector3 genVector3() {
         Vector3 data;
         data.set_x(std::rand());

--- a/test/test_Communication.cpp
+++ b/test/test_Communication.cpp
@@ -419,6 +419,14 @@ BOOST_AUTO_TEST_CASE(check_telemetry_pose) {
   COMPARE_PROTOBUF(send, recv);
 }
 
+BOOST_AUTO_TEST_CASE(check_telemetry_poses) {
+  // not using the set/get functions
+  Poses send, recv;
+  send = TypeGenerator::genPoses();
+  recv = testTelemetry(send, POSES);
+  COMPARE_PROTOBUF(send, recv);
+}
+
 BOOST_AUTO_TEST_CASE(check_telemetry_jointstate) {
   // not using the set/get functions
   JointState send, recv;


### PR DESCRIPTION
The Poses message types has not been used for sharing telemetry. In the scope of PRO-ACT project this would be a useful feature to share the pose of several frames at the same time. Since the message type is already there I added the required getter and setter methods.

Somehow the test is not running without error. @planthaber: could you please have a look?