### PR TITLE
Sort proto file alphabetically & edit poses message

### DIFF
--- a/src/Types/Conversions/ros/geometry_msgs/Pose.hpp
+++ b/src/Types/Conversions/ros/geometry_msgs/Pose.hpp
@@ -22,5 +22,13 @@ namespace RosConversion {
         convert(from, &to->pose);
     }
 
+    inline static void convert(const geometry_msgs::Pose &from, robot_remote_control::Pose *to ) {
+        convert(from.position, to->mutable_position());
+        convert(from.orientation, to->mutable_orientation());
+    }
+    
+    inline static void convert(const geometry_msgs::PoseStamped &from, robot_remote_control::Pose *to ) {
+        convert(from.pose, to);
+    }
 }  // namespace RosConversion
 }  // namespace robot_remote_control

--- a/src/Types/Conversions/ros/nav_msgs/Path.hpp
+++ b/src/Types/Conversions/ros/nav_msgs/Path.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <robot_remote_control/Types/RobotRemoteControl.pb.h>
+#include "../Header.hpp"
+#include "../geometry_msgs/Pose.hpp"
+#include <nav_msgs/Path.h>
+
+namespace robot_remote_control {
+namespace RosConversion {
+
+    static void convert(const nav_msgs::Path &from, robot_remote_control::Poses* to) {
+
+        convert(from.header, to->mutable_timestamp());
+
+        if(not from.header.frame_id.empty()) {
+            to->set_frame(from.header.frame_id);
+        } else {
+            to->set_frame("world");
+        }
+
+        for (const auto & pose : from.poses) {
+            convert(pose, to->add_poses());
+        }
+    }
+
+    static void convert(const robot_remote_control::Poses &from, nav_msgs::Path* to) {
+        for (unsigned int i = 0; i < from.poses_size(); i++) {
+            convert(from.poses(i), &to->poses[i]);
+        }
+    }
+
+}  // namespace RosConversion
+}  // namespace robot_remote_control

--- a/src/Types/RobotRemoteControl.proto
+++ b/src/Types/RobotRemoteControl.proto
@@ -4,37 +4,70 @@ import "google/protobuf/any.proto";
 
 package robot_remote_control;
 
+message Acceleration {
+    Vector3 linear = 1;
+    Vector3 angular = 2;
+}
+
+message ActionDependency {
+    // defined if this action can only be used, if another action has a specific state
+    string depends_on_action = 1; // "task"
+    float depends_on_action_in_state = 2; //1    
+}
+
+message ChannelFloat {
+    string name = 1;
+    repeated float values = 2;
+}
+
+message ComplexAction {
+    string name = 1;
+    ComplexActionType type = 2;
+    repeated Pose poses = 3;
+    repeated Twist twists = 4;
+}
+
+enum ComplexActionType {
+    UNDEFINED_COMPLEX_ACTION = 0;
+    POSE = 1;
+    POSE_LIST = 2;
+    TWIST = 3;
+    TWIST_LIST = 4;
+    AREA = 5;
+    VOLUME = 6;
+}
+
+message ComplexActions {
+    repeated ComplexAction actions = 1;
+}
+
+message ContactPoint {
+    Vector3 position = 1;  // position in body frame
+    float contact = 2;  // contact probability in the interval between 0 and 1.0, or NaN if unknown
+    float slip = 3;  //  slip distance of contact point in a single control loop
+    float friction_coefficient = 4; // friction_coefficient of the current
+    int32 groupId = 5;  //set a group for points that should have contact simultaneously
+}
+
+message ContactPoints {
+    repeated ContactPoint contacts= 1;
+}
+
+message GridMap {
+    TimeStamp timestamp = 1;
+    string frame = 2;
+    Pose origin  = 3;
+    repeated SimpleSensor layers = 4;
+}
+
+message GoTo {
+    double max_forward_speed = 1;
+    Pose waypoint_pose = 2; 
+    double waypoint_max_forward_speed = 3;
+}
+
 message HeartBeat {
     float heartBeatDuration = 1;
-}
-
-message TimeStamp {
-    int32 secs = 1;
-    int32 nsecs = 2;
-}
-
-message Vector2{
-    float x = 1;
-    float y = 2;
-}
-
-message Vector3 {
-    float x = 1;
-    float y = 2;
-    float z = 3;
-}
-
-message Position {
-    double x = 1;
-    double y = 2;
-    double z = 3;
-}
-
-message Orientation {
-    double x = 1;
-    double y = 2;
-    double z = 3;
-    double w = 4;
 }
 
 message IMU {
@@ -42,47 +75,6 @@ message IMU {
     Vector3 gyro = 2;
     Vector3 mag = 3;
     Orientation orientation = 4;
-}
-
-message Pose {
-    Position position = 1;
-    Orientation orientation = 2;
-    float orientation2d = 4;  // only to be used in case position only consists of x and y
-    TimeStamp timestamp = 3;
-}
-
-message Poses {
-    repeated Pose pose = 1;
-}
-
-message Transform {
-    Pose transform = 1;
-    string from = 2;
-    string to = 3;
-    TimeStamp timestamp= 4;
-}
-
-message Transforms {
-    repeated Transform transform = 1;
-}
-
-message Twist {
-    Vector3 linear = 1;
-    Vector3 angular = 2;
-}
-
-message Acceleration {
-    Vector3 linear = 1;
-    Vector3 angular = 2;
-}
-
-message JointState {
-    repeated string name = 1;
-    repeated double position = 2;
-    repeated double velocity = 3;
-    repeated double effort = 4;
-    repeated double acceleration = 6;
-    TimeStamp timestamp = 5;
 }
 
 message JointCommand {
@@ -96,10 +88,35 @@ message JointCommand {
     TimeStamp timestamp = 9;
 }
 
-message GoTo {
-    double max_forward_speed = 1;
-    Pose waypoint_pose = 2; 
-    double waypoint_max_forward_speed = 3;
+message JointState {
+    repeated string name = 1;
+    repeated double position = 2;
+    repeated double velocity = 3;
+    repeated double effort = 4;
+    repeated double acceleration = 6;
+    TimeStamp timestamp = 5;
+}
+
+message LogMessage {
+    uint32 level = 1;
+    string message = 2;
+    TimeStamp timestamp = 3;
+}
+
+message Map {
+    google.protobuf.Any map = 3;
+}
+
+enum MapMessageType {  
+    NO_MAP_DATA = 0;
+    POINTCLOUD_MAP = 1; // the pointcloud proto type
+    GRID_MAP = 2;  // transmitted as SimpleSensor
+    MAP_MESSAGE_TYPES_NUMBER = 3; // LAST element
+}
+
+message MapsDefinition {
+    repeated string name = 1;
+    repeated uint32 id = 2;
 }
 
 message NamedValue {
@@ -107,57 +124,16 @@ message NamedValue {
     float value = 2;
 }
 
-enum SimpleActionType {
-    UNDEFINED = 0;
-    VALUE_INT = 1;
-    VALUE_FLOAT = 2;
-    TRIGGER = 3;
+message Orientation {
+    double x = 1;
+    double y = 2;
+    double z = 3;
+    double w = 4;
 }
 
-message ActionDependency {
-    // defined if this acrion can only be usedif another acrion has anoter 
-    string depends_on_action = 1; // "task"
-    float depends_on_action_in_state = 2; //1    
-}
-
-message SimpleActionDef {
-    SimpleActionType type = 1; // VALUE_INT
-    float min_state = 2;
-    float max_state = 3;
-    float step_size = 4;
-    repeated NamedValue value_names = 5; // {name: barrel_found, value=0}, {name: barrel_close, value=1}
-    ActionDependency action_dependency = 6;
-}
-
-message SimpleAction {
-    string name = 1;
-    SimpleActionDef type = 2;
-    float state = 3;
-}
-
-message SimpleActions {
-     repeated SimpleAction actions = 1;
-}
-
-enum ComplexActionType {
-    UNDEFINED_COMPLEX_ACTION = 0;
-    POSE = 1;
-    POSE_LIST = 2;
-    TWIST = 3;
-    TWIST_LIST = 4;
-    AREA = 5;
-    VOLUME = 6;
-}
-
-message ComplexAction {
-    string name = 1;
-    ComplexActionType type = 2;
-    repeated Pose poses = 3;
-    repeated Twist twists = 4;
-}
-
-message ComplexActions {
-    repeated ComplexAction actions = 1;
+message Permission {
+    string requestuid = 1;
+    bool granted = 2;
 }
 
 message PermissionRequest {
@@ -166,9 +142,32 @@ message PermissionRequest {
     bool granted = 3;
 }
 
-message Permission {
-    string requestuid = 1;
-    bool granted = 2;
+message PointCloud {
+    TimeStamp timestamp = 1;
+    string frame = 2;
+    Pose origin  = 3;
+    repeated Position points = 4;
+    repeated ChannelFloat channels = 5;
+}
+
+message Pose {
+    Position position = 1;
+    Orientation orientation = 2;
+    float orientation2d = 4;  // only to be used in case position only consists of x and y
+    TimeStamp timestamp = 3;
+}
+
+message Poses {
+    TimeStamp timestamp = 1;
+    string frame = 2;         // defaults to world
+    Pose origin  = 3;         // TODO: in converter, set transform from world if no frame is given
+    repeated Pose poses = 4;
+}
+
+message Position {
+    double x = 1;
+    double y = 2;
+    double z = 3;
 }
 
 message RobotName {
@@ -182,19 +181,30 @@ message RobotState {
     repeated string state_name = 2;
 }
 
-message LogMessage {
-    uint32 level = 1;
-    string message = 2;
-    TimeStamp timestamp = 3;
+message SimpleAction {
+    string name = 1;
+    SimpleActionDef type = 2;
+    float state = 3;
 }
 
-message VideoStream{
-    string url = 1;
-    Pose camerapose = 2;
+message SimpleActionDef {
+    SimpleActionType type = 1; // VALUE_INT
+    float min_state = 2;
+    float max_state = 3;
+    float step_size = 4;
+    repeated NamedValue value_names = 5; // {name: barrel_found, value=0}, {name: barrel_close, value=1}
+    ActionDependency action_dependency = 6;
 }
 
-message VideoStreams{
-    repeated VideoStream stream = 1;
+message SimpleActions {
+     repeated SimpleAction actions = 1;
+}
+
+enum SimpleActionType {
+    UNDEFINED = 0;
+    VALUE_INT = 1;
+    VALUE_FLOAT = 2;
+    TRIGGER = 3;
 }
 
 message SimpleSensor{
@@ -215,41 +225,49 @@ message SimpleSensors{
     repeated SimpleSensor sensors = 1;
 }
 
-message Map {
-    google.protobuf.Any map = 3;
+message TimeStamp {
+    int32 secs = 1;
+    int32 nsecs = 2;
 }
 
-enum MapMessageType {  
-    NO_MAP_DATA = 0;
-    POINTCLOUD_MAP = 1; // the pointcloud proto type
-    GRID_MAP = 2;  // transmitted as SimpleSensor
-    MAP_MESSAGE_TYPES_NUMBER = 3; // LAST element
+message Transform {
+    Pose transform = 1;
+    string from = 2;
+    string to = 3;
+    TimeStamp timestamp= 4;
 }
 
-message MapsDefinition {
-    repeated string name = 1;
-    repeated uint32 id = 2;
+message Transforms {
+    repeated Transform transform = 1;
 }
 
-
-message ChannelFloat {
-    string name = 1;
-    repeated float values = 2;
+message Twist {
+    Vector3 linear = 1;
+    Vector3 angular = 2;
 }
 
-message PointCloud {
-    TimeStamp timestamp = 1;
-    string frame = 2;
-    Pose origin  = 3;
-    repeated Position points = 4;
-    repeated ChannelFloat channels = 5;
+message Vector2{
+    float x = 1;
+    float y = 2;
 }
 
-message GridMap {
-    TimeStamp timestamp = 1;
-    string frame = 2;
-    Pose origin  = 3;
-    repeated SimpleSensor layers = 4;
+message Vector3 {
+    float x = 1;
+    float y = 2;
+    float z = 3;
+}
+
+message Vector3Array {
+    repeated Vector3 elements = 1;
+}
+
+message VideoStream{
+    string url = 1;
+    Pose camerapose = 2;
+}
+
+message VideoStreams{
+    repeated VideoStream stream = 1;
 }
 
 message Wrench {
@@ -263,23 +281,6 @@ message WrenchState {
     repeated Wrench wrenches = 3;
 }
 
-message ContactPoint {
-    Vector3 position = 1;  // position in body frame
-    float contact = 2;  // contact probability in the interval between 0 and 1.0, or NaN if unknown
-    float slip = 3;  //  slip distance of contact point in a single control loop
-    float friction_coefficient = 4; // friction_coefficient of the current
-    int32 groupId = 5;  //set a group for points that should have contact simultaneously
-}
-
-message ContactPoints {
-    repeated ContactPoint contacts= 1;
-}
-
-message Vector3Array {
-    repeated Vector3 elements = 1;
-}
-
 // message DepthMap {
 //  // TBD
-
 // }

--- a/test/TypeGenerator.hpp
+++ b/test/TypeGenerator.hpp
@@ -6,58 +6,29 @@ namespace robot_remote_control {
 
 class TypeGenerator{
  public:
-    static Position genPosition() {
-        Position data;
-        data.set_x(std::rand());
-        data.set_y(std::rand());
-        data.set_z(std::rand());
-        return data;
-    }
-
-
-    static Orientation genOrentation() {
-        Orientation data;
-        data.set_x(std::rand());
-        data.set_y(std::rand());
-        data.set_z(std::rand());
-        data.set_w(std::rand());
-        return data;
-    }
-
-    static Pose genPose() {
-        Pose data;
-        *data.mutable_position() = genPosition();
-        *data.mutable_orientation() = genOrentation();
-        return data;
-    }
-
-    static Poses genPoses() {
-        Poses data;
-        for (int values = 0; values < 10; ++values) {
-            *data.add_pose() = genPose();
-        }
-        return data;
-    }
-
-    static Vector3 genVector3() {
-        Vector3 data;
-        data.set_x(std::rand());
-        data.set_y(std::rand());
-        data.set_z(std::rand());
-        return data;
-    }
-
-    static Twist genTwist() {
-        Twist data;
-        *data.mutable_angular() = genVector3();
-        *data.mutable_linear() = genVector3();
-        return data;
-    }
 
     static Acceleration genAcceleration() {
         Acceleration data;
         *data.mutable_angular() = genVector3();
         *data.mutable_linear() = genVector3();
+        return data;
+    }
+
+    static ComplexAction genComplexAction() {
+        ComplexAction data;
+        data.set_name(std::to_string(std::rand()));
+        data.set_type(POSE_LIST);
+        for (int i = 0; i < 10; ++i) {
+            *data.add_poses() = genPose();
+        }
+        return data;
+    }
+
+    static ComplexActions genComplexActions() {
+        ComplexActions data;
+        for (int i = 0; i < 10; ++i) {
+            *data.add_actions() = genComplexAction();
+        }
         return data;
     }
 
@@ -80,21 +51,49 @@ class TypeGenerator{
         return data;
     }
 
-    static Wrench genWrench() {
-        Wrench data;
-        *data.mutable_force() = genVector3();
-        *data.mutable_torque() = genVector3();
+    static Orientation genOrentation() {
+        Orientation data;
+        data.set_x(std::rand());
+        data.set_y(std::rand());
+        data.set_z(std::rand());
+        data.set_w(std::rand());
         return data;
     }
 
-    static WrenchState genWrenchState() {
-        WrenchState data;
+    static Pose genPose() {
+        Pose data;
+        *data.mutable_position() = genPosition();
+        *data.mutable_orientation() = genOrentation();
+        return data;
+    }
+
+    static Poses genPoses() {
+        Poses data;
         for (int values = 0; values < 10; ++values) {
-            *data.add_frame() = std::to_string(values);
-            *data.add_wrenches() = genWrench();
+            *data.add_poses() = genPose();
         }
         return data;
     }
+
+    static Position genPosition() {
+        Position data;
+        data.set_x(std::rand());
+        data.set_y(std::rand());
+        data.set_z(std::rand());
+        return data;
+    }
+
+    static RobotName genRobotName() {
+        RobotName data;
+        data.set_value(std::to_string(std::rand()));
+        return data;
+    }
+
+    // static RobotState genRobotState() {
+    //     RobotState data;
+    //     data.set_state(std::to_string(std::rand()));
+    //     return data;
+    // }
 
     static SimpleActionDef genSimpleActionDef() {
         SimpleActionDef data;
@@ -119,35 +118,28 @@ class TypeGenerator{
         return data;
     }
 
-    static ComplexAction genComplexAction() {
-        ComplexAction data;
-        data.set_name(std::to_string(std::rand()));
-        data.set_type(POSE_LIST);
-        for (int i = 0; i < 10; ++i) {
-            *data.add_poses() = genPose();
-        }
+    static Transform genTransform() {
+        Transform data;
+        *data.mutable_transform() = genPose();
+        data.set_from(std::to_string(std::rand()));
+        data.set_to(std::to_string(std::rand()));
         return data;
     }
 
-    static ComplexActions genComplexActions() {
-        ComplexActions data;
-        for (int i = 0; i < 10; ++i) {
-            *data.add_actions() = genComplexAction();
-        }
+    static Twist genTwist() {
+        Twist data;
+        *data.mutable_angular() = genVector3();
+        *data.mutable_linear() = genVector3();
         return data;
     }
 
-    static RobotName genRobotName() {
-        RobotName data;
-        data.set_value(std::to_string(std::rand()));
+    static Vector3 genVector3() {
+        Vector3 data;
+        data.set_x(std::rand());
+        data.set_y(std::rand());
+        data.set_z(std::rand());
         return data;
     }
-
-    // static RobotState genRobotState() {
-    //     RobotState data;
-    //     data.set_state(std::to_string(std::rand()));
-    //     return data;
-    // }
 
     static VideoStream genVideoStream() {
         VideoStream data;
@@ -164,11 +156,19 @@ class TypeGenerator{
         return data;
     }
 
-    static Transform genTransform() {
-        Transform data;
-        *data.mutable_transform() = genPose();
-        data.set_from(std::to_string(std::rand()));
-        data.set_to(std::to_string(std::rand()));
+    static Wrench genWrench() {
+        Wrench data;
+        *data.mutable_force() = genVector3();
+        *data.mutable_torque() = genVector3();
+        return data;
+    }
+
+    static WrenchState genWrenchState() {
+        WrenchState data;
+        for (int values = 0; values < 10; ++values) {
+            *data.add_frame() = std::to_string(values);
+            *data.add_wrenches() = genWrench();
+        }
         return data;
     }
 

--- a/test/test_RingBuffer.cpp
+++ b/test/test_RingBuffer.cpp
@@ -31,7 +31,7 @@ void fillBuffer(unsigned int size, RingBuffer<int> *buffer, bool overwrite = fal
     }
 
 
-BOOST_AUTO_TEST_CASE(retrun_correctly_on_pop) {
+BOOST_AUTO_TEST_CASE(return_correctly_on_pop) {
     RingBuffer<int> buffer(10);
     int data;
 
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(retrun_correctly_on_pop) {
     BOOST_CHECK_EQUAL(buffer.popData(&data), false);
 }
 
-BOOST_AUTO_TEST_CASE(retrun_correctly_on_push) {
+BOOST_AUTO_TEST_CASE(return_correctly_on_push) {
     RingBuffer<int> buffer(1);
 
     int i = 0;


### PR DESCRIPTION
Add timestamp, frame and origin to poses message definition. Does this require a version number incrementation as it changes the numeration of message fileds for that message?

I added ros Conversions for the nav_msgs/Path. For rock I did not add any conversions yet. There is a preexisting conversion [from Poses to SubTrajectory](https://github.com/dfki-ric/robot_remote_control/blob/devel/src/Types/Conversions/rock/SubTrajectory.hpp). Can we just use that one? The [base::Trajectory ](https://www.rock-robotics.org/apidocs/base/types/structbase_1_1Trajectory.html)type seems odd to me as it is essentially a struct holding a bool and a spline. The conversion from path to a spline object does not seem straight forward to me atm.

Alternatively we could think about sending the entire JointTrajectory instead of the endeffector path. That would allow to animate the steps of the planned path with URDF overlay. Similar to the [visualization of the planned path in RVIZ MotionPlanner](https://ros-planning.github.io/moveit_tutorials/_images/rviz_plan_free.png). For visualization that would be very cool and actually more save as well, but probably too much effort. What do you think about that?