### PR TITLE
Consistent use of headers, updated rock converters (incompatible protocol)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,2 @@
+3.0.0 - consistend use of a header type for metadata in telemetry
 2.0.0

--- a/examples/ControlledRobotMain.cpp
+++ b/examples/ControlledRobotMain.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
     *transform.mutable_transform() = tf_pose;
     transform.set_from("Source");
     transform.set_to("Target");
-    *transform.mutable_timestamp() = robot.getTime();
+    *transform.mutable_header()->mutable_timestamp() = robot.getTime();
     *transforms.add_transform() = transform;
 
     robot.initSimpleActions(simpleActions);
@@ -176,7 +176,7 @@ int main(int argc, char** argv)
             printf("\ngot target pose command:\n%s\n", targetpose.ShortDebugString().c_str());
             robot.setLogMessage(robot_remote_control::INFO, "warping fake robot to target position\n");
             currentpose = targetpose;
-            *(currentpose.mutable_timestamp()) = robot.getTime();
+            *(currentpose.mutable_header()->mutable_timestamp()) = robot.getTime();
         }
 
         if (robot.getTwistCommand(&twistcommand)) {
@@ -250,7 +250,7 @@ int main(int argc, char** argv)
         twistState.mutable_linear()->set_x(1);
         twistState.mutable_linear()->set_y(2);
         twistState.mutable_linear()->set_z(3);
-        twistState.set_frame("Test for a framename");
+        twistState.mutable_header()->set_frame("Test for a framename");
         robot.setCurrentTwist(twistState);
 
         // when the define RRC_STATISTICS was active during compilation you can calculate/print/use stats

--- a/src/Types/Conversions/rock/Joints.hpp
+++ b/src/Types/Conversions/rock/Joints.hpp
@@ -10,7 +10,7 @@ namespace RockConversion {
 
     inline static void convert(const JointState &rrc_type, base::samples::Joints* rock_type) {
         rock_type->clear();
-        convert(rrc_type.timestamp(), &(rock_type->time));
+        convert(rrc_type.header(), &(rock_type->time));
         // init all states
         for (int i = 0; i < rrc_type.name().size(); i++) {
             try {
@@ -38,7 +38,7 @@ namespace RockConversion {
 
     inline static void convert(const JointCommand &rrc_type, base::samples::Joints* rock_type) {
         rock_type->clear();
-        convert(rrc_type.timestamp(), &(rock_type->time));
+        convert(rrc_type.header(), &(rock_type->time));
         // init all states
         for (int i = 0; i < rrc_type.name().size(); i++) {
             try {
@@ -65,7 +65,7 @@ namespace RockConversion {
     }
 
     inline static void convert(const base::samples::Joints &rock_type, JointState *rrc_type) {
-        convert(rock_type.time, rrc_type->mutable_timestamp());
+        convert(rock_type.time, rrc_type->mutable_header());
         // Clear last state
         rrc_type->clear_name();
         rrc_type->clear_position();

--- a/src/Types/Conversions/rock/Pointcloud.hpp
+++ b/src/Types/Conversions/rock/Pointcloud.hpp
@@ -26,14 +26,15 @@ namespace RockConversion {
                 channel->add_values(color[3]);
             }
         }
-        rrc_type->set_frame(frame);
+        rrc_type->mutable_header()->set_frame(frame);
+        convert(rock_type.time, rrc_type->mutable_header()->mutable_timestamp());
     }
 
     inline static void convert(const PointCloud& rrc_type, base::samples::Pointcloud *rock_type) {
         rock_type->points.clear();
         rock_type->colors.clear();
 
-        convert(rrc_type.timestamp(), &(rock_type->time));
+        convert(rrc_type.header().timestamp(), &(rock_type->time));
 
         rock_type->points.reserve(rrc_type.points().size());
         for (auto &point : rrc_type.points()) {

--- a/src/Types/Conversions/rock/RigidBodyState.hpp
+++ b/src/Types/Conversions/rock/RigidBodyState.hpp
@@ -14,13 +14,13 @@ namespace RockConversion {
     }
 
     inline static void convert(const base::samples::RigidBodyState &rock_type, Pose *rrc_type) {
-        convert(rock_type.time, rrc_type->mutable_timestamp());
+        convert(rock_type.time, rrc_type->mutable_header()->mutable_timestamp());
         convert(rock_type.position, rrc_type->mutable_position());
         convert(rock_type.orientation, rrc_type->mutable_orientation());
     }
 
     inline static void convert(const Pose &rrc_type, base::samples::RigidBodyState *rock_type) {
-        convert(rrc_type.timestamp(), &rock_type->time);
+        convert(rrc_type.header().timestamp(), &rock_type->time);
         convert(rrc_type.position(), &rock_type->position);
         convert(rrc_type.orientation(), &rock_type->orientation);
     }

--- a/src/Types/Conversions/rock/Time.hpp
+++ b/src/Types/Conversions/rock/Time.hpp
@@ -16,6 +16,14 @@ namespace RockConversion {
         *rock_type = base::Time::fromSeconds(rrc_type.secs(), rrc_type.nsecs() / 1000);
     }
 
+    inline static void convert(const Header &rrc_type, base::Time *rock_type) {
+        *rock_type = base::Time::fromSeconds(rrc_type.timestamp().secs(), rrc_type.timestamp().nsecs() / 1000);
+    }
+
+    inline static void convert(const base::Time &rock_type, Header *rrc_type) {
+        convert(rock_type, rrc_type->mutable_timestamp());
+        
+    }
 
 }  // namespace RockConversion
 }  // namespace robot_remote_control

--- a/src/Types/Conversions/rock/Twist.hpp
+++ b/src/Types/Conversions/rock/Twist.hpp
@@ -11,19 +11,15 @@ namespace RockConversion {
     inline static void convert(const Twist &rrc_type, base::samples::Twist* rock_type) {
         convert(rrc_type.linear(), &(rock_type->linear));
         convert(rrc_type.angular(), &(rock_type->angular));
-        rock_type->frame_id = rrc_type.frame();
-        if (rrc_type.timestamp().secs() == 0 && rrc_type.timestamp().nsecs() == 0) {
-            rock_type->time = base::Time::now();
-        } else {
-            convert(rrc_type.timestamp(), &(rock_type->time));
-        }
+        rock_type->frame_id = rrc_type.header().frame();
+        convert(rrc_type.header(), &(rock_type->time));
     }
 
     inline static void convert(const base::samples::Twist &rock_type, Twist* rrc_type) {
         convert(rock_type.linear, rrc_type->mutable_linear());
         convert(rock_type.angular, rrc_type->mutable_angular());
-        rrc_type->set_frame(rock_type.frame_id);
-        convert(rock_type.time, rrc_type->mutable_timestamp());
+        rrc_type->mutable_header()->set_frame(rock_type.frame_id);
+        convert(rock_type.time, rrc_type->mutable_header());
     }
 
 }  // namespace RockConversion

--- a/src/Types/Conversions/ros/Header.hpp
+++ b/src/Types/Conversions/ros/Header.hpp
@@ -22,10 +22,10 @@ namespace RosConversion {
     }
 
     static void convert(const robot_remote_control::Header &from, std_msgs::Header *to) {
-        to.seq = from->seq();
-        to.frame_id = from->frame();
-        to->stamp.secs(from.stamp.sec);
-        to->stamp.set_nsecs(from.stamp.nsec);
+        to->seq = from.seq();
+        to->frame_id = from.frame();
+        to->stamp.sec = from.timestamp().secs();
+        to->stamp.nsec = from.timestamp().nsecs();
     }
 
 }  // namespace RosConversion

--- a/src/Types/Conversions/ros/Header.hpp
+++ b/src/Types/Conversions/ros/Header.hpp
@@ -13,5 +13,20 @@ namespace RosConversion {
     }
 
 
+    static void convert(const std_msgs::Header &from, robot_remote_control::Header *to) {
+        to->set_seq(from.seq);
+        to->set_frame(from.frame_id);
+        to->mutable_timestamp()->set_secs(from.stamp.sec);
+        to->mutable_timestamp()->set_nsecs(from.stamp.nsec);
+        
+    }
+
+    static void convert(const robot_remote_control::Header &from, std_msgs::Header *to) {
+        to.seq = from->seq();
+        to.frame_id = from->frame();
+        to->stamp.secs(from.stamp.sec);
+        to->stamp.set_nsecs(from.stamp.nsec);
+    }
+
 }  // namespace RosConversion
 }  // namespace robot_remote_control

--- a/src/Types/Conversions/ros/geometry_msgs/Pose.hpp
+++ b/src/Types/Conversions/ros/geometry_msgs/Pose.hpp
@@ -6,6 +6,7 @@
 #include <geometry_msgs/PoseStamped.h>
 
 #include "Point.hpp"
+#include "Header.hpp"
 #include "Quaternion.hpp"
 
 namespace robot_remote_control {
@@ -16,9 +17,8 @@ namespace RosConversion {
         convert(from.orientation(), &to->orientation);
     }
     
-    inline static void convert(const robot_remote_control::Pose &from, geometry_msgs::PoseStamped *to, const ros::Time &stamp = ros::Time::now(), const std::string &frame_id = "") {
-        to->header.stamp = stamp;
-        to->header.frame_id = frame_id;
+    inline static void convert(const robot_remote_control::Pose &from, geometry_msgs::PoseStamped *to) {
+        convert(from.header(), &to->header);
         convert(from, &to->pose);
     }
 
@@ -28,6 +28,7 @@ namespace RosConversion {
     }
     
     inline static void convert(const geometry_msgs::PoseStamped &from, robot_remote_control::Pose *to ) {
+        convert(from.header, to->mutable_header());
         convert(from.pose, to);
     }
 }  // namespace RosConversion

--- a/src/Types/Conversions/ros/geometry_msgs/Pose.hpp
+++ b/src/Types/Conversions/ros/geometry_msgs/Pose.hpp
@@ -5,8 +5,8 @@
 #include <robot_remote_control/Types/RobotRemoteControl.pb.h>
 #include <geometry_msgs/PoseStamped.h>
 
+#include "../Header.hpp"
 #include "Point.hpp"
-#include "Header.hpp"
 #include "Quaternion.hpp"
 
 namespace robot_remote_control {

--- a/src/Types/Conversions/ros/geometry_msgs/Wrench.hpp
+++ b/src/Types/Conversions/ros/geometry_msgs/Wrench.hpp
@@ -7,12 +7,9 @@ namespace robot_remote_control {
 namespace RosConversion {
 
     static void convert(const geometry_msgs::WrenchStamped &from, robot_remote_control::WrenchState* to) {
-        *(to->add_frame()) = from.header.frame_id;
-        robot_remote_control::TimeStamp *ts = to->mutable_timestamp();
-        ts->set_secs(from.header.stamp.sec);
-        ts->set_nsecs(from.header.stamp.nsec);
-
         robot_remote_control::Wrench *pb_wrench = to->add_wrenches();
+        convert(from.header, pb_wrench->mutable_header());
+
         pb_wrench->mutable_force()->set_x(from.wrench.force.x);
         pb_wrench->mutable_force()->set_y(from.wrench.force.y);
         pb_wrench->mutable_force()->set_z(from.wrench.force.z);

--- a/src/Types/Conversions/ros/sensor_msgs/JointState.hpp
+++ b/src/Types/Conversions/ros/sensor_msgs/JointState.hpp
@@ -8,7 +8,7 @@ namespace robot_remote_control {
 namespace RosConversion {
 
     static void convert(const sensor_msgs::JointState &from, robot_remote_control::JointState* to) {
-        convert(from.header, to->mutable_timestamp());
+        convert(from.header, to->mutable_header());
 
         for (int i = 0; i < from.name.size(); ++i) {
             to->add_name(from.name[i]);

--- a/src/Types/RobotRemoteControl.proto
+++ b/src/Types/RobotRemoteControl.proto
@@ -72,7 +72,7 @@ message ContactPoints {
 }
 
 message GridMap {
-    TimeStamp timestamp = 1;
+    Header header = 1;
     string frame = 2;
     Pose origin  = 3;
     repeated SimpleSensor layers = 4;
@@ -110,37 +110,39 @@ message ImageLayers {
 }
 
 message IMU {
-    Vector3 acceleration = 1;
-    Vector3 gyro = 2;
-    Vector3 mag = 3;
-    Orientation orientation = 4;
-    Header header = 5;
+    Header header = 1;
+    Vector3 acceleration = 2;
+    Vector3 gyro = 3;
+    Vector3 mag = 4;
+    Orientation orientation = 5;
 }
 
 message JointCommand {
-    repeated string name = 1;
-    repeated double position = 2;
-    repeated double velocity = 3;
-    repeated double effort = 4;
+    Header header = 1;
+    repeated string name = 2;
+    repeated double position = 3;
+    repeated double velocity = 4;
+    repeated double effort = 5;
     repeated double acceleration = 6;
-    repeated double kp_gain = 7;
-    repeated double kd_gain = 8;
-    TimeStamp timestamp = 9;
+    repeated uint64 tics = 7;
+    repeated double kp_gain = 8;
+    repeated double kd_gain = 9;
 }
 
 message JointState {
-    repeated string name = 1;
-    repeated double position = 2;
-    repeated double velocity = 3;
-    repeated double effort = 4;
+    Header header = 1;
+    repeated string name = 2;
+    repeated double position = 3;
+    repeated double velocity = 4;
+    repeated double effort = 5;
     repeated double acceleration = 6;
-    TimeStamp timestamp = 5;
+    repeated uint64 tics = 7;
 }
 
 message LogMessage {
-    uint32 level = 1;
-    string message = 2;
-    TimeStamp timestamp = 3;
+    Header header = 1;
+    uint32 level = 2;
+    string message = 3;
 }
 
 message Map {
@@ -172,36 +174,36 @@ message Orientation {
 }
 
 message Permission {
-    string requestuid = 1;
-    bool granted = 2;
-}
-
-message PermissionRequest {
-    string description = 1;
-    string requestuid = 2; // you can use a simple string (number, description again) or a UUID here
+    Header header = 1;
+    string requestuid = 2;
     bool granted = 3;
 }
 
+message PermissionRequest {
+    Header header = 1;
+    string description = 2;
+    string requestuid = 3; // you can use a simple string (number, description again) or a UUID here
+    bool granted = 4;
+}
+
 message PointCloud {
-    TimeStamp timestamp = 1;
-    string frame = 2;
-    Pose origin  = 3;
-    repeated Position points = 4;
-    repeated ChannelFloat channels = 5;
+    Header header = 1;
+    Pose origin  = 2;
+    repeated Position points = 3;
+    repeated ChannelFloat channels = 4;
 }
 
 message Pose {
-    Position position = 1;
-    Orientation orientation = 2;
+    Header header = 1;
+    Position position = 2;
+    Orientation orientation = 3;
     float orientation2d = 4;  // only to be used in case position only consists of x and y
-    TimeStamp timestamp = 3;
 }
 
 message Poses {
-    TimeStamp timestamp = 1;
-    string frame = 2;         // defaults to world
-    Pose origin  = 3;         // TODO: in converter, set transform from world if no frame is given
-    repeated Pose poses = 4;
+    Header header = 1;
+    Pose origin  = 2;         // TODO: in converter, set transform from world if no frame is given
+    repeated Pose poses = 3;
 }
 
 message Position {
@@ -223,16 +225,18 @@ message RobotName {
 }
 
 message RobotState {
-    repeated string state = 1;
+    Header header = 1;
+    repeated string state = 2;
     // the name may be uses in case you nees a description od the state array
     // e.g. "Current Task", it must match the index of the state
-    repeated string state_name = 2;
+    repeated string state_name = 3;
 }
 
 message SimpleAction {
-    string name = 1;
-    SimpleActionDef type = 2;
-    float state = 3;
+    Header header = 1;
+    string name = 2;
+    SimpleActionDef type = 3;
+    float state = 4;
 }
 
 message SimpleActionDef {
@@ -256,13 +260,13 @@ enum SimpleActionType {
 }
 
 message SimpleSensor{
-    string name = 1;
-    uint32 id = 2;
+    Header header = 1;
+    string name = 2;
+    uint32 id = 3;
     //size in x and y in order to send e.g. gridmaps, indexing: val = value[x+y*sizex]
     //if this is a single value, you omit this completely
-    Vector2 size = 3; 
-    repeated float value = 4;
-    TimeStamp timestamp = 5;
+    Vector2 size = 4; 
+    repeated float value = 5;
     //scale for discretized arrays of values of each data point in x and y in SI units (meters, seconds etc.)
     //omit if no scale is needed
     Vector2 scale = 6;
@@ -280,10 +284,10 @@ message TimeStamp {
 }
 
 message Transform {
-    Pose transform = 1;
-    string from = 2;
-    string to = 3;
-    TimeStamp timestamp = 4;
+    Header header = 1;
+    Pose transform = 2;
+    string from = 3;
+    string to = 4;
 }
 
 message Transforms {
@@ -291,10 +295,9 @@ message Transforms {
 }
 
 message Twist {
-    Vector3 linear = 1;
-    Vector3 angular = 2;
-    TimeStamp timestamp = 3;
-    string frame = 4;
+    Header header = 1;
+    Vector3 linear = 2;
+    Vector3 angular = 3;
 }
 
 message Vector2{
@@ -322,14 +325,13 @@ message VideoStreams{
 }
 
 message Wrench {
-    Vector3 force = 1;
-    Vector3 torque = 2;
+    Header header = 1;
+    Vector3 force = 2;
+    Vector3 torque = 3;
 }
 
 message WrenchState {
-    TimeStamp timestamp = 1;
-    repeated string frame = 2;
-    repeated Wrench wrenches = 3;
+    repeated Wrench wrenches = 1;
 }
 
 // message DepthMap {

--- a/test/TypeGenerator.hpp
+++ b/test/TypeGenerator.hpp
@@ -173,6 +173,7 @@ class TypeGenerator{
 
     static Wrench genWrench() {
         Wrench data;
+        *data.mutable_header() = genHeader();
         *data.mutable_force() = genVector3();
         *data.mutable_torque() = genVector3();
         return data;
@@ -181,7 +182,6 @@ class TypeGenerator{
     static WrenchState genWrenchState() {
         WrenchState data;
         for (int values = 0; values < 10; ++values) {
-            *data.add_frame() = genString();
             *data.add_wrenches() = genWrench();
         }
         return data;


### PR DESCRIPTION
This cleans up the .proto file and adda a Header message similar to the ROS header, which is the first entry of each message. 
Due to the re-ordering of the message definitions and changes from Timestamp to header use, this makes the lib incompatible to older versions of the library