### PR TITLE
ROS conversion headers

### DIFF
--- a/src/Types/Conversions/ros/geometry_msgs/Acceleration.hpp
+++ b/src/Types/Conversions/ros/geometry_msgs/Acceleration.hpp
@@ -2,11 +2,13 @@
 
 #include <robot_remote_control/Types/RobotRemoteControl.pb.h>
 #include <geometry_msgs/AccelStamped.h>
+#include "../Header.hpp"
 
 namespace robot_remote_control {
 namespace RosConversion {
         inline static void convert(const robot_remote_control::Acceleration &from, geometry_msgs::AccelStamped *to ) {
-             to->header.stamp = ros::Time::now();
+             convert(from.header(), &to->header);
+             
              to->accel.angular.x = from.angular().x();
              to->accel.angular.y = from.angular().y();
              to->accel.angular.z = from.angular().z();

--- a/src/Types/Conversions/ros/geometry_msgs/Twist.hpp
+++ b/src/Types/Conversions/ros/geometry_msgs/Twist.hpp
@@ -3,13 +3,14 @@
 #include <string>
 #include <robot_remote_control/Types/RobotRemoteControl.pb.h>
 #include <geometry_msgs/TwistStamped.h>
+#include "../Header.hpp"
 
 namespace robot_remote_control {
 namespace RosConversion {
 
-    inline static void convert(const robot_remote_control::Twist &from, geometry_msgs::TwistStamped *to, const std::string &frame_id="base_link", const ros::Time &time = ros::Time::now() ) {
-        to->header.stamp = time;
-        to->header.frame_id = frame_id;
+    inline static void convert(const robot_remote_control::Twist &from, geometry_msgs::TwistStamped *to) {
+        convert(from.header(), &to->header);
+        
         to->twist.angular.x = from.angular().x();
         to->twist.angular.y = from.angular().y();
         to->twist.angular.z = from.angular().z();

--- a/src/Types/Conversions/ros/geometry_msgs/Wrench.hpp
+++ b/src/Types/Conversions/ros/geometry_msgs/Wrench.hpp
@@ -2,6 +2,7 @@
 
 #include <robot_remote_control/Types/RobotRemoteControl.pb.h>
 #include <geometry_msgs/WrenchStamped.h>
+#include "../Header.hpp"
 
 namespace robot_remote_control {
 namespace RosConversion {

--- a/src/Types/Conversions/ros/nav_msgs/Odometry.hpp
+++ b/src/Types/Conversions/ros/nav_msgs/Odometry.hpp
@@ -2,11 +2,14 @@
 
 #include <robot_remote_control/Types/RobotRemoteControl.pb.h>
 #include <nav_msgs/Odometry.h>
+#include "../Header.hpp"
 
 namespace robot_remote_control {
 namespace RosConversion {
 
     static void convert(const nav_msgs::Odometry &from, robot_remote_control::Pose* to) {
+        convert(from.header, to->mutable_header());
+
         to->mutable_position()->set_x(from.pose.pose.position.x);
         to->mutable_position()->set_y(from.pose.pose.position.y);
         to->mutable_position()->set_z(from.pose.pose.position.z);

--- a/src/Types/Conversions/ros/nav_msgs/Path.hpp
+++ b/src/Types/Conversions/ros/nav_msgs/Path.hpp
@@ -10,11 +10,9 @@ namespace RosConversion {
 
     static void convert(const nav_msgs::Path &from, robot_remote_control::Poses* to) {
 
-        convert(from.header, to->mutable_timestamp());
+        convert(from.header, to->mutable_header());
 
-        if(not from.header.frame_id.empty()) {
-            to->set_frame(from.header.frame_id);
-        } else {
+        if(from.header.frame_id.empty()) {
             to->set_frame("world");
         }
 

--- a/src/Types/Conversions/ros/sensor_msgs/Imu.hpp
+++ b/src/Types/Conversions/ros/sensor_msgs/Imu.hpp
@@ -5,17 +5,20 @@
 
 #include "../geometry_msgs/Quaternion.hpp"
 #include "../geometry_msgs/Vector3.hpp"
+#include "../Header.hpp"
 
 namespace robot_remote_control {
 namespace RosConversion {
 
     static void convert(const robot_remote_control::IMU &from, sensor_msgs::Imu* to) {
+        convert(from.header(), &to->header);
         convert(from.orientation(), &to->orientation);
         convert(from.gyro(), &to->angular_velocity);
         convert(from.acceleration(), &to->linear_acceleration);
     }
 
     static void convert(const sensor_msgs::Imu &from, robot_remote_control::IMU* to) {
+        convert(from.header, to->mutable_header());
         convert(from.orientation, to->mutable_orientation());
         convert(from.angular_velocity, to->mutable_gyro());
         convert(from.linear_acceleration, to->mutable_acceleration());

--- a/src/Types/Conversions/ros/sensor_msgs/PointCloud.hpp
+++ b/src/Types/Conversions/ros/sensor_msgs/PointCloud.hpp
@@ -2,11 +2,14 @@
 
 #include <robot_remote_control/Types/RobotRemoteControl.pb.h>
 #include <geometry_msgs/PoseStamped.h>
+#include "../Header.hpp"
 
 namespace robot_remote_control {
 namespace RosConversion {
 
     static void convert(const sensor_msgs::PointCloud &from, robot_remote_control::PointCloud* to) {
+        convert(from.header, to->mutable_header());
+
         for (auto &point : from.points) {
             robot_remote_control::Position* pos = to->add_points();
             pos->set_x(point.x);

--- a/src/Types/Conversions/ros/tf/StampedTransform.hpp
+++ b/src/Types/Conversions/ros/tf/StampedTransform.hpp
@@ -2,11 +2,14 @@
 
 #include <robot_remote_control/Types/RobotRemoteControl.pb.h>
 #include <tf/transform_datatypes.h>
+#include "../Header.hpp"
 
 namespace robot_remote_control {
 namespace RosConversion {
 
     static void convert(const tf::StampedTransform &from, robot_remote_control::Pose *to) {
+        convert(from.header, to->mutable_header());
+
         tf::Vector3 pos = from.getOrigin();
         robot_remote_control::Position *rrc_pos = to->mutable_position();
         rrc_pos->set_x(pos.getX());


### PR DESCRIPTION
For type conversions for ROS, the conversion of the header is inconsistent:
- sometimes the convert function from `Header.hpp` is used
- sometimes the header is ignored and
- sometimes the header contents are expected as parameters

This was changed to always use the convert function from `Header.hpp` for all ROS messages that contain a header.