### PR TITLE
WIP: added draft of conversion functions for ROS image types

### DIFF
--- a/src/Types/Conversions/rock/Image.hpp
+++ b/src/Types/Conversions/rock/Image.hpp
@@ -10,7 +10,15 @@
 namespace robot_remote_control {
 namespace RockConversion {
 
-    static const boost::bimap<std::string, base::samples::frame::frame_mode_t> encodings = {
+    // https://stackoverflow.com/a/31841462
+    template <typename L, typename R>
+    boost::bimap<L, R>
+    make_bimap(std::initializer_list<typename boost::bimap<L, R>::value_type> list)
+    {
+        return boost::bimap<L, R>(list.begin(), list.end());
+    }
+
+    static const boost::bimap<std::string, base::samples::frame::frame_mode_t> encodings = make_bimap<std::string, base::samples::frame::frame_mode_t>({
             {"MODE_UNDEFINED", base::samples::frame::MODE_UNDEFINED},
             {"MODE_BAYER", base::samples::frame::MODE_BAYER},
             {"MODE_BAYER_RGGB", base::samples::frame::MODE_BAYER_RGGB},
@@ -25,7 +33,7 @@ namespace RockConversion {
             {"MODE_PJPG", base::samples::frame::MODE_PJPG},
             {"MODE_JPEG", base::samples::frame::MODE_JPEG},
             {"MODE_PNG", base::samples::frame::MODE_PNG}
-    };
+    });
 
     // inline static void convert(const IMU &rrc_type, base::samples::IMUSensors* rock_type) {
     //     convert(rrc_type.acceleration(), &(rock_type->acc));
@@ -47,18 +55,18 @@ namespace RockConversion {
         rrc_type->set_data(std::string(reinterpret_cast<const char*>(rock_type.image.data()), rock_type.getNumberOfBytes()));
     }
 
-    inline static void convert(Image const &rrc_type, base::samples::frame::Frame *rock_type, ) {
+    inline static void convert(Image const &rrc_type, base::samples::frame::Frame *rock_type) {
 
-        convert(rrc_type.header().timestamp(), rock_type->time);
+        convert(rrc_type.header().timestamp(), &rock_type->time);
         auto const encoding_mode = encodings.left.find(rrc_type.encoding());
         base::samples::frame::frame_mode_t encoding = encoding_mode != encodings.left.end()
                 ? encoding_mode->second : base::samples::frame::MODE_UNDEFINED;
 
-        rock_type->init(rrc_type.width(), rrc_type.height(), 8, encoding, 0, rrc_type.data.size());
+        rock_type->init(rrc_type.width(), rrc_type.height(), 8, encoding, 0, rrc_type.data().size());
 
 //        rrc_type->set_step(rock_type.getRowSize());
 //        rrc_type->set_is_bigendian(true);
-        rock_type->setImage(rrc_type.data.data(), rrc_type.data().size());
+        rock_type->setImage(rrc_type.data().data(), rrc_type.data().size());
     }
 
 

--- a/src/Types/Conversions/ros/sensor_msgs/CompressedImage.hpp
+++ b/src/Types/Conversions/ros/sensor_msgs/CompressedImage.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <algorithm>
+
+#include <robot_remote_control/Types/RobotRemoteControl.pb.h>
+#include <sensor_msgs/CompressedImage.h>
+
+#include "../Header.hpp"
+
+namespace robot_remote_control {
+namespace RosConversion {
+
+    static void convert(const robot_remote_control::Image &from, sensor_msgs::CompressedImage* to) {
+        convert(from.header(), &(to->header));
+        // TODO: translate encodings (throw errors if selected one is not compatible, e.g., MODE_PNG?)
+        // compressed images use other message type: sensor_msgs::CompressedImage 
+        auto const& encoding = from.encoding();
+        if (encoding == "MODE_JPEG") {
+            to->format = "jpg";
+        }
+        else if (encoding == "MODE_PNG") {
+            to->format = "png";
+        }
+        else {
+            // encoding unsupported, leave original value as hint, as to how to interpret the data
+            to->format = encoding;
+        }
+        auto const& data = from.data();
+        to->data.reserve(data.size());
+        std::copy(data.begin(), data.end(), to->data.begin());
+    }
+
+    static void convert(const sensor_msgs::CompressedImage &from, robot_remote_control::Image* to) {
+        convert(from.header, to->mutable_header());
+        // TODO: translate encodings (throw errors if selected one is not compatible, e.g., MODE_PNG?)
+        // compressed images use other message type: sensor_msgs::CompressedImage 
+        auto const& format = from.format;
+        if (format == "jpg") {
+            to->mutable_encoding() = "MODE_JPEG";
+        }
+        else if (format == "png") {
+            to->mutable_encoding() = "MODE_PNG";
+        }
+        else {
+            // encoding unsupported, leave original value as hint, as to how to interpret the data
+            to->mutable_encoding() = format;
+        }
+        auto const& data = from.data;
+        to->mutable_data().reserve(data.size());
+        std::copy(data.begin(), data.end(), to->mutable_data().begin());
+    }
+
+}  // namespace RosConversion
+}  // namespace robot_remote_control

--- a/src/Types/Conversions/ros/sensor_msgs/CompressedImage.hpp
+++ b/src/Types/Conversions/ros/sensor_msgs/CompressedImage.hpp
@@ -26,7 +26,7 @@ namespace RosConversion {
             to->format = encoding;
         }
         auto const& data = from.data();
-        to->data.reserve(data.size());
+        to->data.resize(data.size());
         std::copy(data.begin(), data.end(), to->data.begin());
     }
 
@@ -35,19 +35,19 @@ namespace RosConversion {
         // TODO: translate encodings (throw errors if selected one is not compatible, e.g., MODE_PNG?)
         // compressed images use other message type: sensor_msgs::CompressedImage 
         auto const& format = from.format;
-        if (format == "jpg") {
-            to->mutable_encoding() = "MODE_JPEG";
+        if (format.find("jpeg") != std::string::npos) {
+            to->set_encoding("MODE_JPEG");
         }
-        else if (format == "png") {
-            to->mutable_encoding() = "MODE_PNG";
+        else if (format.find("png") != std::string::npos) {
+            to->set_encoding("MODE_PNG");
         }
         else {
             // encoding unsupported, leave original value as hint, as to how to interpret the data
-            to->mutable_encoding() = format;
+            to->set_encoding(format);
         }
         auto const& data = from.data;
-        to->mutable_data().reserve(data.size());
-        std::copy(data.begin(), data.end(), to->mutable_data().begin());
+        to->mutable_data()->resize(data.size());
+        std::copy(data.begin(), data.end(), to->mutable_data()->begin());
     }
 
 }  // namespace RosConversion

--- a/src/Types/Conversions/ros/sensor_msgs/Image.hpp
+++ b/src/Types/Conversions/ros/sensor_msgs/Image.hpp
@@ -26,16 +26,15 @@ namespace RosConversion {
 
     static void convert(const sensor_msgs::Image &from, robot_remote_control::Image* to) {
         convert(from.header, to->mutable_header());
-        to->mutable_height() = from.height;
-        to->mutable_width() = from.width;
+        to->set_height(from.height);
+        to->set_width(from.width);
         // TODO: translate encodings (throw errors if selected one is not compatible, e.g., MODE_PNG?)
         // compressed images use other message type: sensor_msgs::CompressedImage 
-        to->mutable_encoding() = from.encoding;
-        to->mutable_is_bigendian() = from.is_bigendian;
-        to->mutable_step() = from.step;
-        auto const& data = from.data;
-        to->mutable_data().reserve(data.size());
-        std::copy(data.begin(), data.end(), to->mutable_data().begin());
+        to->set_encoding(from.encoding);
+        to->set_is_bigendian(from.is_bigendian);
+        to->set_step(from.step);
+        to->mutable_data()->resize(from.data.size());
+        std::copy(from.data.begin(), from.data.end(), to->mutable_data()->begin());
     }
 
 }  // namespace RosConversion

--- a/src/Types/Conversions/ros/sensor_msgs/Image.hpp
+++ b/src/Types/Conversions/ros/sensor_msgs/Image.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <algorithm>
+
+#include <robot_remote_control/Types/RobotRemoteControl.pb.h>
+#include <sensor_msgs/Image.h>
+
+#include "../Header.hpp"
+
+namespace robot_remote_control {
+namespace RosConversion {
+
+    static void convert(const robot_remote_control::Image &from, sensor_msgs::Image* to) {
+        convert(from.header(), &(to->header));
+        to->height = from.height();
+        to->width = from.width();
+        // TODO: translate encodings (throw errors if selected one is not compatible, e.g., MODE_PNG?)
+        // compressed images use other message type: sensor_msgs::CompressedImage 
+        to->encoding = from.encoding();
+        to->is_bigendian = from.is_bigendian();
+        to->step = from.step();
+        auto const& data = from.data();
+        to->data.reserve(data.size());
+        std::copy(data.begin(), data.end(), to->data.begin());
+    }
+
+    static void convert(const sensor_msgs::Image &from, robot_remote_control::Image* to) {
+        convert(from.header, to->mutable_header());
+        to->mutable_height() = from.height;
+        to->mutable_width() = from.width;
+        // TODO: translate encodings (throw errors if selected one is not compatible, e.g., MODE_PNG?)
+        // compressed images use other message type: sensor_msgs::CompressedImage 
+        to->mutable_encoding() = from.encoding;
+        to->mutable_is_bigendian() = from.is_bigendian;
+        to->mutable_step() = from.step;
+        auto const& data = from.data;
+        to->mutable_data().reserve(data.size());
+        std::copy(data.begin(), data.end(), to->mutable_data().begin());
+    }
+
+}  // namespace RosConversion
+}  // namespace robot_remote_control

--- a/src/Types/Conversions/ros/sensor_msgs/Image.hpp
+++ b/src/Types/Conversions/ros/sensor_msgs/Image.hpp
@@ -20,7 +20,7 @@ namespace RosConversion {
         to->is_bigendian = from.is_bigendian();
         to->step = from.step();
         auto const& data = from.data();
-        to->data.reserve(data.size());
+        to->data.resize(data.size());
         std::copy(data.begin(), data.end(), to->data.begin());
     }
 


### PR DESCRIPTION
Untested draft for conversions of ROS image message types (compressed and uncompressed) to and from protobuf representation.

Related issue: https://github.com/dfki-ric/robot_remote_control/issues/36