### PR TITLE
Add and fix ros2 type conversions

### DIFF
--- a/src/Types/Conversions/ros2/geometry_msgs/Twist.hpp
+++ b/src/Types/Conversions/ros2/geometry_msgs/Twist.hpp
@@ -30,5 +30,27 @@ namespace RosConversion {
         to->linear.z = from.linear().z();
     }
 
+    inline static void convert(const geometry_msgs::msg::TwistStamped &from, robot_remote_control::Twist *to) {
+        convert(from.header, to->mutable_header());
+
+        to->mutable_angular()->set_x(from.twist.angular.x);
+        to->mutable_angular()->set_y(from.twist.angular.y);
+        to->mutable_angular()->set_z(from.twist.angular.z);
+
+        to->mutable_linear()->set_x(from.twist.linear.x);
+        to->mutable_linear()->set_y(from.twist.linear.y);
+        to->mutable_linear()->set_z(from.twist.linear.z);
+    }
+
+    inline static void convert(const geometry_msgs::msg::Twist &from, robot_remote_control::Twist *to ) {
+        to->mutable_angular()->set_x(from.angular.x);
+        to->mutable_angular()->set_y(from.angular.y);
+        to->mutable_angular()->set_z(from.angular.z);
+
+        to->mutable_linear()->set_x(from.linear.x);
+        to->mutable_linear()->set_y(from.linear.y);
+        to->mutable_linear()->set_z(from.linear.z);
+    }
+
 }  // namespace RosConversion
 }  // namespace robot_remote_control

--- a/src/Types/Conversions/ros2/geometry_msgs/Vector3.hpp
+++ b/src/Types/Conversions/ros2/geometry_msgs/Vector3.hpp
@@ -12,7 +12,7 @@ namespace RosConversion {
         to->z = from.z();
     }
 
-    inline static void convert(const geometry_msgs::Vector3 &from, robot_remote_control::msg::Vector3 *to ) {
+    inline static void convert(const geometry_msgs::msg::Vector3 &from, robot_remote_control::Vector3 *to ) {
         to->set_x(from.x);
         to->set_y(from.y);
         to->set_z(from.z);

--- a/src/Types/Conversions/ros2/geometry_msgs/Wrench.hpp
+++ b/src/Types/Conversions/ros2/geometry_msgs/Wrench.hpp
@@ -20,6 +20,17 @@ namespace RosConversion {
         pb_wrench->mutable_torque()->set_z(from.wrench.torque.z);
     }
 
+    static void convert(const robot_remote_control::WrenchState &from, geometry_msgs::msg::WrenchStamped* to) {
+        convert(from.wrenches(0).header(), &to->header);
+
+        to->wrench.force.x = from.wrenches(0).force().x();
+        to->wrench.force.y = from.wrenches(0).force().y();
+        to->wrench.force.z = from.wrenches(0).force().z();
+
+        to->wrench.torque.x = from.wrenches(0).torque().x();
+        to->wrench.torque.y = from.wrenches(0).torque().y();
+        to->wrench.torque.z = from.wrenches(0).torque().z();
+    }
 
 }  // namespace RosConversion
 }  // namespace robot_remote_control

--- a/src/Types/Conversions/ros2/sensor_msgs/CompressedImage.hpp
+++ b/src/Types/Conversions/ros2/sensor_msgs/CompressedImage.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <robot_remote_control/Types/RobotRemoteControl.pb.h>
+#include <sensor_msgs/msg/compressed_image.hpp>
+
+#include "../Header.hpp"
+
+namespace robot_remote_control {
+namespace RosConversion {
+
+    static void convert(const robot_remote_control::Image &from, sensor_msgs::msg::CompressedImage* to) {
+        convert(from.header(), &(to->header));
+        // TODO: translate encodings (throw errors if selected one is not compatible, e.g., MODE_PNG?)
+        // compressed images use other message type: sensor_msgs::CompressedImage 
+        auto const& encoding = from.encoding();
+        if (encoding == "MODE_JPEG") {
+            to->format = "jpg";
+        }
+        else if (encoding == "MODE_PNG") {
+            to->format = "png";
+        }
+        else {
+            // encoding unsupported, leave original value as hint, as to how to interpret the data
+            to->format = encoding;
+        }
+        auto const& data = from.data();
+        to->data.resize(data.size());
+        std::copy(data.begin(), data.end(), to->data.begin());
+    }
+
+    static void convert(const sensor_msgs::msg::CompressedImage &from, robot_remote_control::Image* to) {
+        convert(from.header, to->mutable_header());
+        // TODO: translate encodings (throw errors if selected one is not compatible, e.g., MODE_PNG?)
+        // compressed images use other message type: sensor_msgs::CompressedImage 
+        auto const& format = from.format;
+        if (format.find("jpeg") != std::string::npos) {
+            to->set_encoding("MODE_JPEG");
+        }
+        else if (format.find("png") != std::string::npos) {
+            to->set_encoding("MODE_PNG");
+        }
+        else {
+            // encoding unsupported, leave original value as hint, as to how to interpret the data
+            to->set_encoding(format);
+        }
+        auto const& data = from.data;
+        to->mutable_data()->resize(data.size());
+        std::copy(data.begin(), data.end(), to->mutable_data()->begin());
+    }
+
+}  // namespace RosConversion
+}  // namespace robot_remote_control

--- a/src/Types/Conversions/ros2/sensor_msgs/Image.hpp
+++ b/src/Types/Conversions/ros2/sensor_msgs/Image.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <robot_remote_control/Types/RobotRemoteControl.pb.h>
+#include <sensor_msgs/msg/image.hpp>
+#include <boost/bimap.hpp>
+#include <string>
+
+#include "../Header.hpp"
+
+namespace robot_remote_control {
+namespace RosConversion {
+
+    // https://stackoverflow.com/a/31841462
+    template <typename L, typename R>
+    boost::bimap<L, R>
+    make_bimap(std::initializer_list<typename boost::bimap<L, R>::value_type> list)
+    {
+        return boost::bimap<L, R>(list.begin(), list.end());
+    }
+    static const boost::bimap<std::string, std::string> encodings = make_bimap<std::string, std::string>({
+        {"MODE_BAYER_RGGB", "bayer_rggb8"},
+        {"MODE_BAYER_BGGR", "bayer_bggr8"},
+        {"MODE_BAYER_GBRG", "bayer_gbrg8"},
+        {"MODE_BAYER_GRBG", "bayer_grbg8"},
+        {"MODE_GRAYSCALE", "mono8"},
+        {"MODE_RGB", "rgb8"},
+        {"MODE_BGR", "bgr8"}
+    });
+
+    static void convert(const robot_remote_control::Image &from, sensor_msgs::msg::Image* to) {
+        convert(from.header(), &(to->header));
+        to->height = from.height();
+        to->width = from.width();
+        if (encodings.right.find(from.encoding()) != encodings.right.end()) {
+            // encoding supported
+            to->encoding = encodings.right.at(from.encoding());
+        } else {
+            // encoding unsupported, leave original value as hint, as to how to interpret the data
+            to->encoding = from.encoding();
+        }
+        to->is_bigendian = from.is_bigendian();
+        to->step = from.step();
+        auto const& data = from.data();
+        to->data.resize(data.size());
+        std::copy(data.begin(), data.end(), to->data.begin());
+    }
+
+    static void convert(const sensor_msgs::msg::Image &from, robot_remote_control::Image* to) {
+        convert(from.header, to->mutable_header());
+        to->set_height(from.height);
+        to->set_width(from.width);
+        if (encodings.left.find(from.encoding) != encodings.left.end()) {
+            // encoding supported
+            to->set_encoding(encodings.left.at(from.encoding));
+        } else {
+            // encoding unsupported, leave original value as hint, as to how to interpret the data
+            to->set_encoding(from.encoding);
+        }
+        to->set_is_bigendian(from.is_bigendian);
+        to->set_step(from.step);
+        to->mutable_data()->resize(from.data.size());
+        std::copy(from.data.begin(), from.data.end(), to->mutable_data()->begin());
+    }
+
+}  // namespace RosConversion
+}  // namespace robot_remote_control

--- a/src/Types/Conversions/ros2/sensor_msgs/Imu.hpp
+++ b/src/Types/Conversions/ros2/sensor_msgs/Imu.hpp
@@ -17,7 +17,7 @@ namespace RosConversion {
         convert(from.acceleration(), &to->linear_acceleration);
     }
 
-    static void convert(const sensor_msgs::Imu &from, robot_remote_control::msg::IMU* to) {
+    static void convert(const sensor_msgs::msg::Imu &from, robot_remote_control::IMU* to) {
         convert(from.header, to->mutable_header());
         convert(from.orientation, to->mutable_orientation());
         convert(from.angular_velocity, to->mutable_gyro());

--- a/src/Types/Conversions/ros2/sensor_msgs/JointState.hpp
+++ b/src/Types/Conversions/ros2/sensor_msgs/JointState.hpp
@@ -24,5 +24,22 @@ namespace RosConversion {
         }
     }
 
+    static void convert(const robot_remote_control::JointState &from, sensor_msgs::msg::JointState* to) {
+        convert(from.header(), &to->header);
+
+        for (int i = 0; i < from.name_size(); ++i) {
+            to->name.push_back(from.name(i));
+            if (from.position_size()) {
+                to->position.push_back(from.position(i));
+            }
+            if (from.velocity_size()) {
+                to->velocity.push_back(from.velocity(i));
+            }
+            if (from.effort_size()) {
+                to->effort.push_back(from.effort(i));
+            }
+        }
+    }
+
 }  // namespace RosConversion
 }  // namespace robot_remote_control

--- a/src/Types/Conversions/ros2/sensor_msgs/PointCloud2.hpp
+++ b/src/Types/Conversions/ros2/sensor_msgs/PointCloud2.hpp
@@ -24,5 +24,25 @@ namespace RosConversion {
         }
     }
 
+    static void convert(const robot_remote_control::PointCloud &pointcloud, sensor_msgs::msg::PointCloud2* to) {
+        convert(pointcloud.header(), &to->header);
+
+        sensor_msgs::PointCloud2Modifier modifier(*to);
+        modifier.setPointCloud2Fields(3, "x", 1, sensor_msgs::msg::PointField::FLOAT32,
+                                            "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+                                            "z", 1, sensor_msgs::msg::PointField::FLOAT32);
+        modifier.resize(pointcloud.points_size());
+
+        sensor_msgs::PointCloud2Iterator<float> iter_x(*to, "x");
+        sensor_msgs::PointCloud2Iterator<float> iter_y(*to, "y");
+        sensor_msgs::PointCloud2Iterator<float> iter_z(*to, "z");
+
+        for (int i = 0; i < pointcloud.points_size(); ++i, ++iter_x, ++iter_y, ++iter_z) {
+            *iter_x = pointcloud.points(i).x();
+            *iter_y = pointcloud.points(i).y();
+            *iter_z = pointcloud.points(i).z();
+        }
+    }
+
 }  // namespace RosConversion
 }  // namespace robot_remote_control


### PR DESCRIPTION
Fixes types, where the `msg` part was included in the rrc type instead of the ros2 type:
- `Vector3`
- `Imu`

Adds ros2 conversions for:
- `TwistStamped` and `Twist` (to rrc)
- `WrenchStamped` (to ros2)
- `JointState` (to ros2)
- `PointCloud2` (to ros2)
- `Image` and `CompressedImage`