### PR TITLE
JPEG compression and frame_id

### DIFF
--- a/src/Types/Conversions/rock/Image.hpp
+++ b/src/Types/Conversions/rock/Image.hpp
@@ -57,7 +57,6 @@ namespace RockConversion {
     }
 
     inline static void convert(Image const &rrc_type, base::samples::frame::Frame *rock_type) {
-        convert(rrc_type.header().timestamp(), &rock_type->time);
         auto const encoding_mode = encodings.left.find(rrc_type.encoding());
         base::samples::frame::frame_mode_t encoding = encoding_mode != encodings.left.end()
                 ? encoding_mode->second : base::samples::frame::MODE_UNDEFINED;
@@ -67,7 +66,7 @@ namespace RockConversion {
             rock_type->init(rrc_type.width(), rrc_type.height(), 8, encoding, 0, rrc_type.data().size());
             rock_type->setImage(rrc_type.data().data(), rrc_type.data().size());
         }
-        else if(encoding != base::samples::frame::MODE_JPEG)
+        else if(encoding == base::samples::frame::MODE_JPEG)
         {
             frame_helper::FrameHelper::loadFrameJPEG(reinterpret_cast<const uint8_t*>(rrc_type.data().data()), rrc_type.data().size(), *rock_type);
         }
@@ -75,6 +74,9 @@ namespace RockConversion {
         {
             throw std::runtime_error("Only MODE_JPEG or uncompressed frames are supported at the moment");
         }
+        convert(rrc_type.header(), &(rock_type->time));
+        rock_type->received_time = base::Time::now();
+        rock_type->frame_status = base::samples::frame::STATUS_VALID;
     }
 
 }  // namespace RockConversion

--- a/src/Types/Conversions/rock/Image.hpp
+++ b/src/Types/Conversions/rock/Image.hpp
@@ -75,6 +75,7 @@ namespace RockConversion {
             throw std::runtime_error("Only MODE_JPEG or uncompressed frames are supported at the moment");
         }
         convert(rrc_type.header(), &(rock_type->time));
+        rock_type->setAttribute("frame_id", rrc_type.header().frame());
         rock_type->received_time = base::Time::now();
         rock_type->frame_status = base::samples::frame::STATUS_VALID;
     }

--- a/src/Types/Conversions/rock/Image.hpp
+++ b/src/Types/Conversions/rock/Image.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <robot_remote_control/Types/RobotRemoteControl.pb.h>
 #include <base/samples/Frame.hpp>
+#include <frame_helper/FrameHelper.h>
 #include <boost/bimap.hpp>
 
 
@@ -61,11 +62,19 @@ namespace RockConversion {
         base::samples::frame::frame_mode_t encoding = encoding_mode != encodings.left.end()
                 ? encoding_mode->second : base::samples::frame::MODE_UNDEFINED;
 
-        rock_type->init(rrc_type.width(), rrc_type.height(), 8, encoding, 0, rrc_type.data().size());
-
-//        rrc_type->set_step(rock_type.getRowSize());
-//        rrc_type->set_is_bigendian(true);
-        rock_type->setImage(rrc_type.data().data(), rrc_type.data().size());
+        if(encoding < base::samples::frame::COMPRESSED_MODES)
+        {
+            rock_type->init(rrc_type.width(), rrc_type.height(), 8, encoding, 0, rrc_type.data().size());
+            rock_type->setImage(rrc_type.data().data(), rrc_type.data().size());
+        }
+        else if(encoding != base::samples::frame::MODE_JPEG)
+        {
+            frame_helper::FrameHelper::loadFrameJPEG(reinterpret_cast<const uint8_t*>(rrc_type.data().data()), rrc_type.data().size(), *rock_type);
+        }
+        else
+        {
+            throw std::runtime_error("Only MODE_JPEG or uncompressed frames are supported at the moment");
+        }
     }
 
 }  // namespace RockConversion


### PR DESCRIPTION
There were some changes which had not yet been merged to devel to support JPEG compressed frames.
I also write the "frame_id" as an attribute now