### PR TITLE
Add Simple action helper class

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,4 @@
+5.0.2 - allow requestChannelsDefinition to only fill internel structures
 5.0.1 - Fix virtual_joystick increment setting
 5.0.0 - Channel support
 4.0.0 - added CLI, api change fpr simpleactions

--- a/src/RobotController/RobotController.hpp
+++ b/src/RobotController/RobotController.hpp
@@ -423,7 +423,7 @@ class RobotController: public UpdateThread {
 
         bool requestChannelsDefinition() {
             ChannelsDefinition channels;
-            requestChannelsDefinition(&channels);
+            return requestChannelsDefinition(&channels);
         }
 
         ChannelId getMaxChannelNo(const MessageId& MessageId) {

--- a/src/RobotController/RobotController.hpp
+++ b/src/RobotController/RobotController.hpp
@@ -421,6 +421,11 @@ class RobotController: public UpdateThread {
             return result;
         }
 
+        bool requestChannelsDefinition() {
+            ChannelsDefinition channels;
+            requestChannelsDefinition(&channels);
+        }
+
         ChannelId getMaxChannelNo(const MessageId& MessageId) {
             return messageChannels[MessageId];
         }

--- a/src/Tools/CMakeLists.txt
+++ b/src/Tools/CMakeLists.txt
@@ -8,11 +8,6 @@ target_include_directories(robot_remote_control-send_timers
 		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/robot_remote_control
-	FILES_MATCHING PATTERN "*.hpp"
-)
-
 install (TARGETS robot_remote_control-send_timers
         EXPORT robot_remote_control-targets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -44,3 +39,25 @@ if(ZLIB_FOUND)
                 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         )
 endif()
+
+
+add_library(robot_remote_control-simple_action_helper
+            SimpleActionHelper.cpp
+            )
+
+target_include_directories(robot_remote_control-simple_action_helper
+	PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+install (TARGETS robot_remote_control-simple_action_helper
+        EXPORT robot_remote_control-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/robot_remote_control
+	FILES_MATCHING PATTERN "*.hpp"
+)

--- a/src/Tools/SimpleActionHelper.cpp
+++ b/src/Tools/SimpleActionHelper.cpp
@@ -1,0 +1,127 @@
+#include "SimpleActionHelper.hpp"
+
+
+
+
+SimpleActionsHelper::SimpleActionsHelper(const robot_remote_control::SimpleActions& initfrom) {
+    initFrom(initfrom);
+}
+
+void SimpleActionsHelper::initFrom(const robot_remote_control::SimpleActions& initfrom) {
+    actions.Clear();
+    actionbyname.clear();
+
+    actions.CopyFrom(initfrom);
+
+    //restore access buffers
+    for (auto& action : *actions.mutable_actions()) {
+        std::shared_ptr<SimpleActionWrapper> wrapper = std::make_shared<SimpleActionWrapper>(&action);
+        actionbyname[action.name()] = wrapper;
+
+        // restore valueByName access buffer
+        for (auto& namedValue : action.type().value_names()) {
+            wrapper->valueByName[namedValue.name()] = namedValue.value();
+            wrapper->nameByValue[namedValue.value()] = namedValue.name();
+        }
+        // restore actionDependencyStates access buffer
+        for (const auto & dep : action.type().action_dependency()) {
+            wrapper->actionDependencyStates[dep.depends_on_action()].push_back(dep.depends_on_action_in_state());
+        }
+    }
+}
+
+const robot_remote_control::SimpleActions& SimpleActionsHelper::getSimpleActionsDefinition() {
+    return actions;
+}
+
+std::shared_ptr<SimpleActionWrapper> SimpleActionsHelper::getSimpleAction(const std::string &actionname) {
+    return actionbyname[actionname];
+}
+
+float SimpleActionsHelper::getActionState(const std::string &actionname) {
+    return getSimpleAction(actionname)->getState();
+}
+
+void SimpleActionsHelper::setActionState(const std::string &actionname, const float &value) {
+    getSimpleAction(actionname)->setState(value);
+}
+
+std::shared_ptr<SimpleActionWrapper> SimpleActionsHelper::addSimpleAction(const std::string &actionname, const robot_remote_control::SimpleActionType& type) {
+    robot_remote_control::SimpleAction* action = actions.add_actions();
+    action->set_name(actionname);
+    action->mutable_type()->set_type(type);
+    std::shared_ptr<SimpleActionWrapper> wrapper = std::make_shared<SimpleActionWrapper>(action);
+    actionbyname[actionname] = wrapper;
+    return wrapper;
+}
+
+bool SimpleActionsHelper::canExecute(const std::shared_ptr<SimpleActionWrapper> &action) {    
+    //check dependencies (multiple entries on single actions: OR, between actions: AND)
+    for (const auto& actionstate : action->actionDependencyStates) {
+        bool has_match = false;
+        float curr_state = getActionState(actionstate.first);
+        //check or relation, if one is matching, the action has the correct state
+        for (const auto& state : actionstate.second) {
+            if (state ==  curr_state) {
+                has_match = true;
+            }
+        }
+        // if no state this action is not matching, action has unmet deps
+        if (!has_match) {
+            return false;
+        }
+    }
+    return true;
+}
+
+
+
+
+
+
+
+SimpleActionWrapper::SimpleActionWrapper(robot_remote_control::SimpleAction* action): action(action) {
+
+}
+
+void SimpleActionWrapper::setLimits(const float &min_state, const float &max_state, const float &step_size) {
+    action->mutable_type()->set_min_state(min_state);
+    action->mutable_type()->set_max_state(max_state);
+    action->mutable_type()->set_step_size(step_size);
+}
+
+/**
+ * @brief add named values to action as a 
+ * 
+ * @param valuenames 
+ */
+void SimpleActionWrapper::addNamedValues(const std::map<std::string, float> & valuenames) {
+    for (const auto& entry : valuenames) {
+        addNamedValue(entry.first, entry.second);
+    }
+}
+
+void SimpleActionWrapper::addNamedValue(const std::string &name, const float &value) {
+    robot_remote_control::NamedValue *nv = action->mutable_type()->add_value_names();
+    nv->set_name(name);
+    nv->set_value(value);
+    valueByName[name] = value;
+    nameByValue[value] = name;
+}
+
+float SimpleActionWrapper::getNamedValue(const std::string &valuename) {
+    return valueByName[valuename];
+}
+
+std::string SimpleActionWrapper::getValueName(const float &value) {
+    return nameByValue[value];
+}
+
+void SimpleActionWrapper::addActionDependency(const std::string &name, const float &value) {
+    robot_remote_control::ActionDependency* dep = action->mutable_type()->add_action_dependency();
+    dep->set_depends_on_action(name);
+    dep->set_depends_on_action_in_state(value);
+    actionDependencyStates[name].push_back(value);
+}
+
+

--- a/src/Tools/SimpleActionHelper.hpp
+++ b/src/Tools/SimpleActionHelper.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <memory>
+#include "../Types/RobotRemoteControl.pb.h"
+
+
+class SimpleActionWrapper;
+
+
+/**
+ * @brief helper definitions to handle Simpleactions and dependencies more easily
+ * Usage: create this class, use the function of this classes to configure simpleactions, and finally use 
+ * 
+ * SimpleActionsHelper simpleactions;
+ * simpleactions.addAction() 
+ * [...]
+ * controlledrobot.initSimpleActions(simpleactions.getSimpleActionsDefinition());
+ * 
+ * see tests/test_SimpleActionHelper.cpp for more examples
+ */
+class SimpleActionsHelper {
+ public:
+
+    SimpleActionsHelper(){}
+    SimpleActionsHelper(const robot_remote_control::SimpleActions& initfrom);
+    virtual ~SimpleActionsHelper(){}
+
+    /**
+     * @brief add a action to 
+     * 
+     * @param actionname 
+     * @param type 
+     * @return std::shared_ptr<SimpleActionWrapper> 
+     */
+    std::shared_ptr<SimpleActionWrapper> addSimpleAction(const std::string &actionname, const robot_remote_control::SimpleActionType& type);
+
+    /**
+     * @brief Get the Simple Actions Definition object to be passed to ControlledRobot::initSimpleActions()
+     * 
+     * @return const robot_remote_control::SimpleActions& 
+     */
+    const robot_remote_control::SimpleActions& getSimpleActionsDefinition();
+
+    /**
+     * @brief Get the Simple Action object in case the return value of addSimpleAction was not stored
+     * 
+     * @param actionname 
+     * @return std::shared_ptr<SimpleActionWrapper> 
+     */
+    std::shared_ptr<SimpleActionWrapper> getSimpleAction(const std::string &actionname);
+
+    /**
+     * @brief Set the current state in the action decription, needed to use canExecute()
+     * can also be set on the SimpleActionWrapper directly
+     * 
+     * @param actionname 
+     * @param value 
+     */
+    void setActionState(const std::string &actionname, const float &value);
+
+    /**
+     * @brief Get the state of a action
+     * can also be set on the SimpleActionWrapper directly
+     * 
+     * @param actionname 
+     * @return float 
+     */
+    float getActionState(const std::string &actionname);
+
+    /**
+     * @brief check if the dependencies of the simpleaction are met
+     * 
+     * @warning You'll need to keep track of the current states using setState()
+     * @param action the action to check if dependencies are met
+     * @return true if all dependencies are ok
+     * @return false if on of the dependencies is not met
+     */
+    bool canExecute(const std::shared_ptr<SimpleActionWrapper> &action);
+
+    /**
+     * @brief wrapper for canExecute in case you have not saved the action object std::shared_ptr<SimpleActionWrapper>
+     */
+    bool canExecute(const std::string &actionname) {
+        return canExecute(actionbyname[actionname]);
+    }
+
+ private:    
+    void initFrom(const robot_remote_control::SimpleActions& initfrom);
+    robot_remote_control::SimpleActions actions;
+    std::map<std::string, std::shared_ptr<SimpleActionWrapper>> actionbyname;
+
+};
+
+/**
+ * @brief wrapper around a single action
+ * 
+ */
+class SimpleActionWrapper {
+ public:
+
+    SimpleActionWrapper(robot_remote_control::SimpleAction* action);
+    virtual ~SimpleActionWrapper(){}
+
+    void setLimits(const float &min_state, const float &max_state, const float &step_size);
+
+    void addNamedValues(const std::map<std::string, float> & valuenames);
+
+    void addNamedValue(const std::string &name, const float &value);
+
+    float getNamedValue(const std::string &valuename);
+
+    std::string getValueName(const float &valuename);
+
+    void addActionDependency(const std::string &name, const float &value);
+
+    void setState(const float &value) {
+        action->set_state(value);
+    }
+    void setState(const std::string &valuename) {
+        setState(getNamedValue(valuename));
+    }
+
+    float getState() {
+        return action->state();
+    }
+
+    robot_remote_control::SimpleActionType getType() {
+        return action->type().type();
+    }
+
+    
+    const robot_remote_control::SimpleAction& getAction() {
+        return *action;
+    }
+
+ private:
+    robot_remote_control::SimpleAction* action;
+
+    friend class SimpleActionsHelper;
+    std::map<std::string, float> valueByName;
+    std::map<float, std::string> nameByValue;
+
+    std::map<std::string, std::vector<float> > actionDependencyStates;
+
+};
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ set (COMMON_SOURCE suite.cpp
             test_RingBuffer.cpp
             test_Thread.cpp
             test_SendTimers.cpp
+            test_SimpleActionHelper.cpp
 )
 set (COMMON_LIBS
    ${CMAKE_THREAD_LIBS_INIT}
@@ -20,6 +21,7 @@ set (COMMON_LIBS
    robot_remote_control-controlled_robot
    robot_remote_control-robot_controller
    robot_remote_control-send_timers
+   robot_remote_control-simple_action_helper
    ${Boost_LIBRARIES}
 )
 

--- a/test/test_SimpleActionHelper.cpp
+++ b/test/test_SimpleActionHelper.cpp
@@ -1,0 +1,93 @@
+#include <boost/test/unit_test.hpp>
+
+#include "../src/Tools/SimpleActionHelper.hpp"
+#include "../src/MessageTypes.hpp"
+#include "../src/Types/RobotRemoteControl.pb.h"
+
+using namespace robot_remote_control;
+
+
+BOOST_AUTO_TEST_CASE(simple_action_helper) {
+   
+SimpleActionsHelper helper;
+
+std::shared_ptr<SimpleActionWrapper> action1 = helper.addSimpleAction("action1", robot_remote_control::VALUE_INT);
+std::shared_ptr<SimpleActionWrapper> action2 = helper.addSimpleAction("action2", robot_remote_control::VALUE_FLOAT);
+std::shared_ptr<SimpleActionWrapper> action3 = helper.addSimpleAction("action3", robot_remote_control::TRIGGER);
+
+
+BOOST_CHECK_EQUAL(action1->getType(), robot_remote_control::VALUE_INT);
+BOOST_CHECK_EQUAL(action2->getType(), robot_remote_control::VALUE_FLOAT);
+BOOST_CHECK_EQUAL(action3->getType(), robot_remote_control::TRIGGER);
+
+action1->setLimits(-1,3,1);
+BOOST_CHECK_EQUAL(action1->getAction().type().min_state(), -1);
+BOOST_CHECK_EQUAL(action1->getAction().type().max_state(), 3);
+BOOST_CHECK_EQUAL(action1->getAction().type().step_size(), 1);
+
+action1->addNamedValues({ {"VAL1", 1}, {"VAL2", 2},{"VAL3", 3} });
+BOOST_CHECK_EQUAL(action1->getAction().type().value_names(0).value(), 1);
+BOOST_CHECK_EQUAL(action1->getAction().type().value_names(1).value(), 2);
+BOOST_CHECK_EQUAL(action1->getAction().type().value_names(2).value(), 3);
+
+BOOST_CHECK_EQUAL(action1->getNamedValue("VAL1"), 1);
+BOOST_CHECK_EQUAL(action1->getNamedValue("VAL2"), 2);
+BOOST_CHECK_EQUAL(action1->getNamedValue("VAL3"), 3);
+
+BOOST_CHECK_EQUAL(action1->getValueName(1), "VAL1");
+BOOST_CHECK_EQUAL(action1->getValueName(2), "VAL2");
+BOOST_CHECK_EQUAL(action1->getValueName(3), "VAL3");
+
+
+action1->setState("VAL2");
+BOOST_CHECK_EQUAL(action1->getState(), 2);
+
+
+// helper.getSimpleActionsDefinition().PrintDebugString();
+
+action1->addActionDependency("action2", 3);
+action1->addActionDependency("action2", 4);// or relation
+
+BOOST_CHECK_EQUAL(helper.canExecute(action1), false);
+action2->setState(3);
+BOOST_CHECK_EQUAL(helper.canExecute(action1), true);
+action2->setState(4);
+BOOST_CHECK_EQUAL(helper.canExecute(action1), true);
+action2->setState(5);
+BOOST_CHECK_EQUAL(helper.canExecute(action1), false);
+
+// add a and dependency on another action
+action1->addActionDependency("action3", 1);
+BOOST_CHECK_EQUAL(helper.canExecute(action1), false);
+action2->setState(3);
+action3->setState(1);
+BOOST_CHECK_EQUAL(helper.canExecute(action1), true);
+action3->setState(0);
+BOOST_CHECK_EQUAL(helper.canExecute(action1), false);
+
+// actions without deps can always be executed
+BOOST_CHECK_EQUAL(helper.canExecute(action2), true);
+
+
+
+// check copy/restore
+SimpleActionsHelper helper2(helper.getSimpleActionsDefinition());
+
+BOOST_TEST(helper.getSimpleActionsDefinition().SerializeAsString() == helper2.getSimpleActionsDefinition().SerializeAsString());
+BOOST_TEST(helper.getSimpleAction("action1")->getAction().SerializeAsString() == helper2.getSimpleAction("action1")->getAction().SerializeAsString());
+BOOST_CHECK_EQUAL(helper.getSimpleAction("action1")->getNamedValue("VAL2"), helper2.getSimpleAction("action1")->getNamedValue("VAL2"));
+
+BOOST_CHECK_EQUAL(helper2.getSimpleAction("action1")->getType(), robot_remote_control::VALUE_INT);
+BOOST_CHECK_EQUAL(helper2.getSimpleAction("action2")->getType(), robot_remote_control::VALUE_FLOAT);
+BOOST_CHECK_EQUAL(helper2.getSimpleAction("action3")->getType(), robot_remote_control::TRIGGER);
+
+BOOST_CHECK_EQUAL(helper2.canExecute(action1), false);
+helper2.setActionState("action3", 1);
+BOOST_CHECK_EQUAL(helper2.canExecute(action1), true);
+
+// now we set a state on the copy, they are different
+BOOST_TEST(helper.getSimpleActionsDefinition().SerializeAsString() != helper2.getSimpleActionsDefinition().SerializeAsString());
+
+
+}
+


### PR DESCRIPTION
The class helps with managing SimpleActions and dependencies. 

* setup of action value limits with less calls
* setup of named Values with less calls
  *  can use std::map init addNamedValues({ {"VAL1", 1}, {"VAL2", 2},{"VAL3", 3} });
* action states can be set using functions
  * to make the curretn state requestable by requestSimpleActions() 
  * to be able to check if the action dependencies are met using canExecute()

```cpp
SimpleActionsHelper helper;

std::shared_ptr<SimpleActionWrapper> action1 = helper.addSimpleAction("action1", robot_remote_control::VALUE_INT);
action1->setLimits(-1,3,1);
action1->addNamedValues({ {"VAL1", 1}, {"VAL2", 2},{"VAL3", 3} });
action1->setState("VAL2");
action1->addActionDependency("action2", 3);
action1->addActionDependency("action2", 4);
```