### PR TITLE
New filetransfer (possibility to hide robot folder information)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if( BUILD_EXAMPLES )
     add_subdirectory(examples)
 endif( BUILD_EXAMPLES )
 
-set (BUILD_TESTS ON)
+#set (BUILD_TESTS ON)
 if( BUILD_TESTS )
     message("Adding test directory") 
     add_subdirectory(test)

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,4 @@
+5.0.3 - Allow path overrides for file transfers
 5.0.2 - allow requestChannelsDefinition to only fill internel structures
 5.0.1 - Fix virtual_joystick increment setting
 5.0.0 - Channel support

--- a/src/ControlledRobot/ControlledRobot.cpp
+++ b/src/ControlledRobot/ControlledRobot.cpp
@@ -263,7 +263,7 @@ bool ControlledRobot::loadFile(FileTransfer* file, const std::string &path, bool
     return false;
 }
 
-bool ControlledRobot::loadFolder(Folder* folder, const std::string &path, bool compressed, const std::string &remotePath) {
+bool ControlledRobot::loadFolder(FolderTransfer* folder, const std::string &path, bool compressed, const std::string &remotePath) {
     try {
         for (const auto & entry : std::experimental::filesystem::recursive_directory_iterator(path)) {
             FileTransfer* file = folder->add_file();
@@ -315,7 +315,7 @@ ControlMessageType ControlledRobot::handlePermissionRequest(const std::string& s
 ControlMessageType ControlledRobot::handleFileRequest(const std::string& serializedMessage, robot_remote_control::TransportSharedPtr commandTransport) {
     FileRequest request;
     request.ParseFromString(serializedMessage);
-    Folder folder;
+    FolderTransfer folder;
     std::string buf;
     int index = -1;
     for (int i = 0; i < files.file().size(); ++i) {

--- a/src/ControlledRobot/ControlledRobot.cpp
+++ b/src/ControlledRobot/ControlledRobot.cpp
@@ -233,7 +233,7 @@ std::string ControlledRobot::serializeControlMessageType(const ControlMessageTyp
 }
 
 
-bool ControlledRobot::loadFile(File* file, const std::string &path, bool compressed) {
+bool ControlledRobot::loadFile(FileTransfer* file, const std::string &path, bool compressed) {
     file->set_path(path);
     // read file (if it is and directory, no data is set)
     std::ifstream in(path, std::ios::in | std::ios::binary);
@@ -260,7 +260,7 @@ bool ControlledRobot::loadFile(File* file, const std::string &path, bool compres
 bool ControlledRobot::loadFolder(Folder* folder, const std::string &path, bool compressed) {
     try {
         for (const auto & entry : std::experimental::filesystem::recursive_directory_iterator(path)) {
-            File* file = folder->add_file();
+            FileTransfer* file = folder->add_file();
             loadFile(file, entry.path(), compressed);
         }
         folder->set_compressed(compressed);
@@ -321,7 +321,7 @@ ControlMessageType ControlledRobot::handleFileRequest(const std::string& seriali
         if (isFolder) {
             loadFolder(&folder, filedef.path(), request.compressed());
         } else {
-            File* file = folder.add_file();
+            FileTransfer* file = folder.add_file();
             loadFile(file, filedef.path(), request.compressed());
             folder.set_compressed(request.compressed());
         }

--- a/src/ControlledRobot/ControlledRobot.hpp
+++ b/src/ControlledRobot/ControlledRobot.hpp
@@ -612,9 +612,9 @@ class ControlledRobot: public UpdateThread {
 
         virtual ControlMessageType evaluateRequest(const std::string& request);
 
-        bool loadFile(FileTransfer* file, const std::string &path, bool compressed = false);
+        bool loadFile(FileTransfer* file, const std::string &path, bool compressed = false, const std::string &remotePath = "");
 
-        bool loadFolder(Folder* folder, const std::string &path, bool compressed = false);
+        bool loadFolder(Folder* folder, const std::string &path, bool compressed = false, const std::string &remotePath = "");
 
         void notifyCommandCallbacks(const MessageId &type);
 

--- a/src/ControlledRobot/ControlledRobot.hpp
+++ b/src/ControlledRobot/ControlledRobot.hpp
@@ -385,10 +385,7 @@ class ControlledRobot: public UpdateThread {
          * @param files name:path list of named files/foilders that can be downloaded
          * @return int 
          */
-        int initFiles(const FileDefinition& files) {
-            this->files.MergeFrom(files);
-            return sendTelemetry(files, FILE_DEFINITION, true, 0);
-        }
+        int initFiles(const FileDefinition& files);
 
         int initRobotModel(const FileDefinition& filedef, const std::string& modelfilename = "") {
             RobotModelInformation modelinfo;
@@ -641,7 +638,7 @@ class ControlledRobot: public UpdateThread {
 
         std::vector< std::function<void(const MessageId &type)> > commandCallbacks;
 
-        FileDefinition files;
+        FileDefinition remote_files, internal_files;
         HeartBeat heartbeatValues;
         Timer heartbeatTimer;
         float heartbeatAllowedLatency;

--- a/src/ControlledRobot/ControlledRobot.hpp
+++ b/src/ControlledRobot/ControlledRobot.hpp
@@ -612,7 +612,7 @@ class ControlledRobot: public UpdateThread {
 
         virtual ControlMessageType evaluateRequest(const std::string& request);
 
-        bool loadFile(File* file, const std::string &path, bool compressed = false);
+        bool loadFile(FileTransfer* file, const std::string &path, bool compressed = false);
 
         bool loadFolder(Folder* folder, const std::string &path, bool compressed = false);
 

--- a/src/ControlledRobot/ControlledRobot.hpp
+++ b/src/ControlledRobot/ControlledRobot.hpp
@@ -614,7 +614,7 @@ class ControlledRobot: public UpdateThread {
 
         bool loadFile(FileTransfer* file, const std::string &path, bool compressed = false, const std::string &remotePath = "");
 
-        bool loadFolder(Folder* folder, const std::string &path, bool compressed = false, const std::string &remotePath = "");
+        bool loadFolder(FolderTransfer* folder, const std::string &path, bool compressed = false, const std::string &remotePath = "");
 
         void notifyCommandCallbacks(const MessageId &type);
 

--- a/src/RobotController/RobotController.cpp
+++ b/src/RobotController/RobotController.cpp
@@ -390,7 +390,7 @@ bool RobotController::requestFile(const std::string &identifier, const bool &com
         request.set_compressed(false);
     #endif
 
-    Folder folder;
+    FolderTransfer folder;
 
     bool result = requestProtobuf(request, &folder, FILE_REQUEST, overrideMaxLatency);
     if (result) {

--- a/src/Types/CMakeLists.txt
+++ b/src/Types/CMakeLists.txt
@@ -6,7 +6,7 @@ if (DEFINED ${PROTOBUF_IMPORT_DIRS})
         set (RRC_PROTO_INCLUDES -I ${CMAKE_CURRENT_SOURCE_DIR} -I ${PROTOBUF_IMPORT_DIRS})
 endif()
 
-message("${PROTOBUF_PROTOC_EXECUTABLE} -I ${CMAKE_CURRENT_SOURCE_DIR} -I ${PROTOBUF_IMPORT_DIRS} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} RobotRemoteControl.proto")
+#message("${PROTOBUF_PROTOC_EXECUTABLE} -I ${CMAKE_CURRENT_SOURCE_DIR} -I ${PROTOBUF_IMPORT_DIRS} --cpp_out=${CMAKE_CURRENT_SOURCE_DIR} RobotRemoteControl.proto")
 
 add_custom_command( OUTPUT RobotRemoteControl.pb.cc RobotRemoteControl.pb.h
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/Types/RobotRemoteControl.proto
+++ b/src/Types/RobotRemoteControl.proto
@@ -183,14 +183,12 @@ message FileTransfer {
     bytes data = 2;
 }
 
-message Folder {
+message FolderTransfer {
     string identifier = 1;
     bool compressed = 2;
     repeated FileTransfer file = 3;
     int32 uncompressed_size = 4;
 }
-
-
 
 message FileRequest {
     string identifier = 1;

--- a/src/Types/RobotRemoteControl.proto
+++ b/src/Types/RobotRemoteControl.proto
@@ -170,20 +170,27 @@ message ControllableFrames {
 message File {
     string identifier = 1;
     string path = 2;
-    bytes data = 4;
-}
-
-message Folder {
-    string identifier = 1;
-    bool compressed = 2;
-    repeated File file = 3;
-    int32 uncompressed_size = 4;
+    string remote_path = 3;
 }
 
 message FileDefinition {
     repeated File file = 1;
     repeated bool isFolder = 2;
 }
+
+message FileTransfer {
+    string path = 1;
+    bytes data = 2;
+}
+
+message Folder {
+    string identifier = 1;
+    bool compressed = 2;
+    repeated FileTransfer file = 3;
+    int32 uncompressed_size = 4;
+}
+
+
 
 message FileRequest {
     string identifier = 1;

--- a/test/test_Communication.cpp
+++ b/test/test_Communication.cpp
@@ -1084,11 +1084,22 @@ BOOST_AUTO_TEST_CASE(file_transfer) {
 
     robot.initFiles(files);
 
+    // set up how the received definitions should look like on the Controller side
+    FileDefinition remote;
+    remote.CopyFrom(files);
+    for (auto& file : *remote.mutable_file()) {
+        if (file.remote_path().size()) {
+            // hide local path from RobotController
+            file.set_path(file.remote_path());
+            file.set_remote_path("");
+        }
+    }
 
+    // Get Definition via Transport
     FileDefinition availablefiles;
     controller.requestAvailableFiles(&availablefiles);
 
-    COMPARE_PROTOBUF(files, availablefiles);
+    COMPARE_PROTOBUF(remote, availablefiles);
 
     // download folder
     BOOST_CHECK_EQUAL(controller.requestFile("folder", false, "./folder"), true);
@@ -1123,6 +1134,8 @@ BOOST_AUTO_TEST_CASE(file_transfer) {
     BOOST_CHECK_EQUAL(controller.requestFile("renamedfolder", false, "./folder6"), true);
     BOOST_TEST(boost::filesystem::exists("./folder6/renamedfolder/subfolderfile"));
     BOOST_TEST(isFileEqual("./test/testfiles/subfolder/subfolderfile", "./folder6/renamedfolder/subfolderfile"));
+
+
 
 
     // cleanup

--- a/test/test_Communication.cpp
+++ b/test/test_Communication.cpp
@@ -1133,7 +1133,7 @@ BOOST_AUTO_TEST_CASE(file_transfer) {
     boost::filesystem::remove_all("./folder5");
     boost::filesystem::remove_all("./folder6");
 
-    // with compression
+    // with compression (test just the transfer, not renaming)
     // download folder
     BOOST_CHECK_EQUAL(controller.requestFile("folder", true, "./cfolder"), true);
     BOOST_TEST(boost::filesystem::exists("./cfolder/test/testfiles/topfolderfile"));

--- a/test/test_Communication.cpp
+++ b/test/test_Communication.cpp
@@ -1065,6 +1065,23 @@ BOOST_AUTO_TEST_CASE(file_transfer) {
     file->set_identifier("subfolderfile");
     file->set_path("./test/testfiles/subfolder/subfolderfile");
 
+    file = files.add_file();
+    files.add_isfolder(false);
+    file->set_identifier("renamedfile");
+    file->set_path("./test/testfiles/subfolder/subfolderfile");
+    file->set_remote_path("./renamed_file");
+
+    file = files.add_file();
+    files.add_isfolder(true);
+    file->set_identifier("subfolder");
+    file->set_path("./test/testfiles/subfolder");
+
+    file = files.add_file();
+    files.add_isfolder(true);
+    file->set_identifier("renamedfolder");
+    file->set_path("./test/testfiles/subfolder");
+    file->set_remote_path("./renamedfolder");
+
     robot.initFiles(files);
 
 
@@ -1093,11 +1110,28 @@ BOOST_AUTO_TEST_CASE(file_transfer) {
     BOOST_TEST(!boost::filesystem::exists("./folder3/test/testfiles/topfolderfile"));
     BOOST_TEST(isFileEqual("./test/testfiles/subfolder/subfolderfile", "./folder3/test/testfiles/subfolder/subfolderfile"));
 
+    // download renamed subfolder file (change path)
+    BOOST_CHECK_EQUAL(controller.requestFile("renamedfile", false, "./folder4"), true);
+    BOOST_TEST(boost::filesystem::exists("./folder4/renamed_file"));
+    BOOST_TEST(isFileEqual("./test/testfiles/subfolder/subfolderfile", "./folder4/renamed_file"));
+
+    // subfolder
+    BOOST_CHECK_EQUAL(controller.requestFile("subfolder", false, "./folder5"), true);
+    BOOST_TEST(boost::filesystem::exists("./folder5/test/testfiles/subfolder/subfolderfile"));
+
+    // relocate folder
+    BOOST_CHECK_EQUAL(controller.requestFile("renamedfolder", false, "./folder6"), true);
+    BOOST_TEST(boost::filesystem::exists("./folder6/renamedfolder/subfolderfile"));
+    BOOST_TEST(isFileEqual("./test/testfiles/subfolder/subfolderfile", "./folder6/renamedfolder/subfolderfile"));
+
 
     // cleanup
     boost::filesystem::remove_all("./folder");
     boost::filesystem::remove_all("./folder2");
     boost::filesystem::remove_all("./folder3");
+    boost::filesystem::remove_all("./folder4");
+    boost::filesystem::remove_all("./folder5");
+    boost::filesystem::remove_all("./folder6");
 
     // with compression
     // download folder
@@ -1127,6 +1161,10 @@ BOOST_AUTO_TEST_CASE(file_transfer) {
     // non-existent ID leads to error
     BOOST_CHECK_EQUAL(controller.requestFile("", false, "./"), false);
     BOOST_CHECK_EQUAL(controller.requestFile("nonexist", false, "./"), false);
+
+
+
+
 }
 
 #ifdef TRANSPORT_DEFAULT


### PR DESCRIPTION
By default, the global path is transmitted trough the api during file transfer (or a Robot Model), as described here:  https://github.com/dfki-ric/robot_remote_control/issues/59

This PR adds the option to rename files or folders for the Controller on robot side.
To do so, set the "remote_path" in the File definition for acual files or folders.

```cpp
    FileDefinition files;
    File* file;

    file = files.add_file();
    files.add_isfolder(false);
    file->set_identifier("renamedfile");
    file->set_path("./test/testfiles/subfolder/subfolderfile");
    file->set_remote_path("./renamed_file");

    file = files.add_file();
    files.add_isfolder(true);
    file->set_identifier("renamedfolder");
    file->set_path("./test/testfiles/subfolder");
    file->set_remote_path("./renamedfolder");

```