### PR TITLE
[draft] Adapt to align with protobuf function definition

### DIFF
--- a/src/RobotController/RobotController.cpp
+++ b/src/RobotController/RobotController.cpp
@@ -258,7 +258,7 @@ bool RobotController::requestMap(Map *map, const ChannelId &channel, const float
     bool result = requestBinary(MAP, &replybuf, TELEMETRY_REQUEST, channel, overrideMaxLatency);
 
     google::protobuf::io::CodedInputStream cistream(reinterpret_cast<const uint8_t *>(replybuf.data()), replybuf.size());
-    cistream.SetTotalBytesLimit(replybuf.size());
+    cistream.SetTotalBytesLimit(replybuf.size(), int(0.9*replybuf.size()));
     map->ParseFromCodedStream(&cistream);
     return result;
 }

--- a/src/RobotController/RobotController.hpp
+++ b/src/RobotController/RobotController.hpp
@@ -651,7 +651,7 @@ class RobotController: public UpdateThread {
             requestBinary(request, &recvbuf, requestType, overrideMaxLatency);
 
             google::protobuf::io::CodedInputStream cistream(reinterpret_cast<const uint8_t *>(recvbuf.data()), recvbuf.size());
-            cistream.SetTotalBytesLimit(recvbuf.size());
+            cistream.SetTotalBytesLimit(recvbuf.size(), int(0.9*recvbuf.size()));
             reply->ParseFromCodedStream(&cistream);
 
             return (recvbuf.size() > 0) ? true : false;


### PR DESCRIPTION
Just figured that this is probably just due to an old version of protobuf in crex. v3.0.0 dates back to 2017 :/

Will check, if this is still an issue with newer protobuf versions.