### PR TITLE
Add libbsd as dependency 

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -13,6 +13,7 @@
   <depend package="protobuf-compiler" />
   <depend package="libreadline" />
   <depend package="zmq" />
+  <depend package="libbsd" />
   <depend package="ncurses" optional="1"/>
 
   <keywords>


### PR DESCRIPTION
needed in the compilation of libzmq with the flags passed

